### PR TITLE
Ensure hybrid controller seeds initial command

### DIFF
--- a/src/simple_hybrid_joint_controller/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller/src/AllJointsHybridController.cpp
@@ -58,6 +58,9 @@ void AllJointsHybridController::starting(const ros::Time&) {
     cmd_[i][2] = default_kp_;               // kp
     cmd_[i][3] = default_kd_;               // kd
     cmd_[i][4] = default_ff_;               // ff
+
+    // 立即写入硬件接口，避免在第一个控制周期中输出未初始化的命令
+    handles_[i].setCommand(cmd_[i][0], cmd_[i][1], cmd_[i][2], cmd_[i][3], cmd_[i][4]);
   }
 }
 


### PR DESCRIPTION
## Summary
- write the startup command directly to each HybridJointHandle so the first control cycle reuses the measured pose
- prevent uninitialized zero targets that caused the motors to spin when bringup_real.launch starts

## Testing
- not run (hardware-dependent)


------
https://chatgpt.com/codex/tasks/task_b_68d6635d4594832383cf81cc70a3b055