### PR TITLE
Refactor Ludan motor layout for structured naming

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -8,6 +8,41 @@
 
 该程序是基于[livelybot_dynamic_control](https://github.com/HighTorque-Robotics/livelybot_dynamic_control)、[hunter_bipedal_control](https://bridgedp.github.io/hunter_bipedal_control)以及[legged_control](https://github.com/qiayuanl/legged_control)上进行一些改进，主要是对**约束**进行了修改。
 
+## Ludan 结构化命名与配置
+
+为了让“ludan”机器人在扩展不同的肢体时保持清晰的命名，本仓库新增了结构化的电机配置方式。所有控制节点都会读取统一的参数，并按照 `机器人名_肢体名_关节名` 的格式在 `/joint_states` 中发布电机名称。
+
+### 关键参数
+
+- `~robot_name`：机器人名称，默认值为 `ludan`。
+- `~motor_layout`：电机布局列表。每个元素需要包含 `limb`（肢体名称）、`joint`（关节名称）以及 `type`（电机型号）。支持的肢体名称不限于 `left_arm`、`right_arm`、`left_leg`、`right_leg`、`waist`、`neck`，也可以自定义，例如 `arm_3`、`aux_leg_1` 等。
+- `~num_motors`：可选备用参数。当未提供 `motor_layout` 时用于指定电机数量。
+
+### 示例配置
+
+可以使用 `rosparam` 或 YAML 文件为机器人配置布局，例如：
+
+```yaml
+robot_name: ludan
+motor_layout:
+  - {limb: right_arm, joint: shoulder_yaw,  type: 10010l}
+  - {limb: right_arm, joint: shoulder_pitch, type: 10010l}
+  - {limb: right_arm, joint: elbow,         type: 6248p}
+  - {limb: right_arm, joint: wrist_yaw,     type: 4340}
+  - {limb: left_arm,  joint: shoulder_yaw,  type: 6248p}
+  - {limb: left_arm,  joint: wrist_roll,    type: 4340}
+  - {limb: waist,     joint: yaw,           type: 10010l}
+  - {limb: neck,      joint: pitch,         type: 4340}
+```
+
+如果未来需要为 ludan 安装 6 个机械臂，只需在 `motor_layout` 中继续添加新的肢体和关节即可，控制程序会自动识别数量并生成对应的串口通信帧。
+
+### 使用建议
+
+1. 肢体名称会自动转为小写并替换为空格的字符，因此建议直接使用英文或数字组合，例如 `left_arm`、`leg_front_left`、`arm_extra_1`。
+2. 若某些肢体暂时没有安装，可保留空列表或直接不在 `motor_layout` 中声明，代码会保持兼容。
+3. 所有串口桥接脚本、测试程序都会根据 `motor_layout` 自动调整数组长度，无需手工修改常量。
+
 ## 学习
 1. 理论框架
 

--- a/src/dmbot_serial/src/robot_connect.cpp
+++ b/src/dmbot_serial/src/robot_connect.cpp
@@ -1,188 +1,354 @@
 #include <dmbot_serial/robot_connect.h>
 
+#include <algorithm>
+#include <cctype>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <ros/console.h>
+#include <xmlrpcpp/XmlRpcValue.h>
 
 namespace dmbot_serial
 {
+namespace
+{
+const std::vector<std::string> kCanonicalLimbs = {"left_arm", "right_arm", "left_leg", "right_leg", "waist", "neck"};
+
+std::string normalizeToken(const std::string& raw)
+{
+  std::string result;
+  result.reserve(raw.size());
+  char last = '\0';
+  for (char c : raw)
+  {
+    const unsigned char uc = static_cast<unsigned char>(c);
+    if (std::isalnum(uc) != 0)
+    {
+      result.push_back(static_cast<char>(std::tolower(uc)));
+      last = result.back();
+    }
+    else if (last != '_')
+    {
+      result.push_back('_');
+      last = '_';
+    }
+  }
+  while (!result.empty() && result.back() == '_')
+  {
+    result.pop_back();
+  }
+  if (result.empty())
+  {
+    return "joint";
+  }
+  return result;
+}
+
+std::string buildMotorName(const std::string& robot, const std::string& limb, const std::string& joint,
+                           std::map<std::string, int>& usage)
+{
+  std::string base = robot + "_" + limb + "_" + joint;
+  std::string candidate = base;
+  int index = 1;
+  while (usage.count(candidate) != 0)
+  {
+    candidate = base + "_" + std::to_string(++index);
+  }
+  usage[candidate] = 1;
+  return candidate;
+}
+
+std::vector<MotorLayoutEntry> parseLayout(const XmlRpc::XmlRpcValue& param)
+{
+  std::vector<MotorLayoutEntry> layout;
+  if (param.getType() != XmlRpc::XmlRpcValue::TypeArray)
+  {
+    return layout;
+  }
+  layout.reserve(param.size());
+  for (int i = 0; i < param.size(); ++i)
+  {
+    if (param[i].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      continue;
+    }
+    MotorLayoutEntry entry;
+    if (param[i].hasMember("limb") && param[i]["limb"].getType() == XmlRpc::XmlRpcValue::TypeString)
+    {
+      entry.limb = static_cast<std::string>(param[i]["limb"]);
+    }
+    if (param[i].hasMember("joint") && param[i]["joint"].getType() == XmlRpc::XmlRpcValue::TypeString)
+    {
+      entry.joint = static_cast<std::string>(param[i]["joint"]);
+    }
+    if (param[i].hasMember("type") && param[i]["type"].getType() == XmlRpc::XmlRpcValue::TypeString)
+    {
+      entry.type = static_cast<std::string>(param[i]["type"]);
+    }
+    if (!entry.limb.empty())
+    {
+      layout.push_back(entry);
+    }
+  }
+  return layout;
+}
+}  // namespace
+
 robot::robot()
 {
+  ros::NodeHandle nh_private("~");
+  nh_private.param<std::string>("robot_name", robot_name, std::string("ludan"));
+  n.param("robot_name", robot_name, robot_name);
+  nh_private.param<std::string>("port", motor_serial_port, std::string("/dev/mcu_rightarm"));
+  nh_private.param("baud", motor_seial_baud, 921600);
 
-  n.param("port", motor_serial_port, std::string("/dev/mcu_rightarm")); 
-  n.param("baud", motor_seial_baud, 921600);
-  
-  int i=0;
-  for(auto& motor:motors)
-  {
-      motor.name = "Motor_" + std::to_string(i);   
-      motor.pos = 0.0f;
-      motor.vel = 0.0f;
-      motor.tor = 0.0f;
-      motor.tor_set = 0.0f;
-      motor.pos_set = 0.0f;
-      motor.vel_set = 0.0f;
-      motor.kp = 0.0f;
-      motor.kd = 0.0f;
-      motor.index=i;
-      i++;
-  }
-  motors[0].type = "10010l";
-  motors[1].type = "10010l";
-  motors[2].type = "10010l";
-  motors[3].type = "6248p";                
-  motors[4].type = "4340";
-  motors[5].type = "4340";   
-  motors[6].type = "4340";
-  
-  // motors[7].type = "10010l";
-  // motors[8].type = "10010l";
-  // motors[9].type = "10010l";                
-  // motors[10].type = "6248p";
-  // motors[11].type = "4340";
-  // motors[12].type = "4340";                
-  // motors[13].type = "4340";
+  initializeMotorConfiguration(loadMotorLayout());
+  ensureReceiveBuffer();
 
-    
-  motors[7].type = "6248p";
-  motors[8].type = "6248p";
-  motors[9].type = "6248p";                
-  motors[10].type = "4340";
-  motors[11].type = "4340";
-  motors[12].type = "4340";                
-  motors[13].type = "4340";
-   
-  init_motor_serial();//初始化串口
+  init_motor_serial();
 
   rec_thread = std::thread(&robot::get_motor_data_thread, this);
-  
-  joint_state_pub = n.advertise<sensor_msgs::JointState>("joint_states", 10);   
- // pub_thread = std::thread(&robot::publishJointStates, this);
+
+  joint_state_pub = n.advertise<sensor_msgs::JointState>("joint_states", 10);
 
   ros::Duration(2.0).sleep();
 
-  ROS_INFO("robot init complete");
-
+  ROS_INFO_STREAM(robot_name << " robot init complete. configured motors: " << motors.size());
 }
+
 robot::~robot()
-{   
-   for(int i=0;i<NUM_MOTORS;i++)
+{
+  for (std::size_t i = 0; i < motors.size(); ++i)
   {
-    fresh_cmd_motor_data(0.0, 0.0, 0.0, 0.0, 0.0, i); //更新发给电机的参数、力矩等
+    fresh_cmd_motor_data(0.0, 0.0, 0.0, 0.0, 0.0, static_cast<int>(i));
   }
-  
+
   send_motor_data();
 
   stop_thread_ = true;
 
-  if(rec_thread.joinable())
+  if (rec_thread.joinable())
   {
-    rec_thread.join(); 
+    rec_thread.join();
   }
   if (serial_motor.isOpen())
   {
-    serial_motor.close(); 
+    serial_motor.close();
   }
-  
- // if(pub_thread.joinable())
-  //{
- //     pub_thread.join(); 
-  //}
-
 }
 
 void robot::init_motor_serial()
-{         
-    try
-    {
-      serial_motor.setPort(motor_serial_port);
-      serial_motor.setBaudrate(motor_seial_baud);
-      serial_motor.setFlowcontrol(serial::flowcontrol_none);
-      serial_motor.setParity(serial::parity_none); //default is parity_none
-      serial_motor.setStopbits(serial::stopbits_one);
-      serial_motor.setBytesize(serial::eightbits);
-      serial::Timeout time_out = serial::Timeout::simpleTimeout(20);
-      serial_motor.setTimeout(time_out);
-      serial_motor.open();
-    } 
-    catch (serial::IOException &e)  // 抓取异常
-    {
-        ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
-        exit(0);
-    }
-    if (serial_motor.isOpen())
-    {
-        ROS_INFO_STREAM("In single initialization,Motor Serial Port initialized");
-    }
-    else
-    {
-        ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
-        exit(0);
-    }
-   
+{
+  try
+  {
+    serial_motor.setPort(motor_serial_port);
+    serial_motor.setBaudrate(motor_seial_baud);
+    serial_motor.setFlowcontrol(serial::flowcontrol_none);
+    serial_motor.setParity(serial::parity_none);
+    serial_motor.setStopbits(serial::stopbits_one);
+    serial_motor.setBytesize(serial::eightbits);
+    serial::Timeout time_out = serial::Timeout::simpleTimeout(20);
+    serial_motor.setTimeout(time_out);
+    serial_motor.open();
+  }
+  catch (serial::IOException& /*e*/)
+  {
+    ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
+    throw;
+  }
+  if (serial_motor.isOpen())
+  {
+    ROS_INFO_STREAM("In single initialization,Motor Serial Port initialized");
+  }
+  else
+  {
+    ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
+    throw std::runtime_error("Unable to open motor serial port");
+  }
+}
+
+void robot::ensureReceiveBuffer()
+{
+  const std::size_t expected = motors.empty() ? 0 : (1 + motors.size() * kFeedbackWordSize + 1);
+  receive_buffer_.assign(expected, 0);
+}
+
+void robot::initializeMotorConfiguration(const std::vector<MotorLayoutEntry>& layout)
+{
+  motors.clear();
+  limb_index_map_.clear();
+  for (const auto& limb : kCanonicalLimbs)
+  {
+    limb_index_map_[normalizeToken(limb)] = {};
+  }
+
+  motors.reserve(layout.size());
+  std::map<std::string, int> name_usage;
+
+  for (std::size_t idx = 0; idx < layout.size(); ++idx)
+  {
+    motor_data_t motor{};
+    motor.index = static_cast<int>(idx);
+    motor.limb = normalizeToken(layout[idx].limb);
+    const std::string joint_token = layout[idx].joint.empty() ? ("joint_" + std::to_string(idx + 1)) : layout[idx].joint;
+    motor.joint = normalizeToken(joint_token);
+    motor.type = layout[idx].type.empty() ? "4340" : layout[idx].type;
+    motor.name = buildMotorName(robot_name, motor.limb, motor.joint, name_usage);
+
+    motor.pos = 0.0f;
+    motor.vel = 0.0f;
+    motor.tor = 0.0f;
+    motor.tor_set = 0.0f;
+    motor.pos_set = 0.0f;
+    motor.vel_set = 0.0f;
+    motor.kp = 0.0f;
+    motor.kd = 0.0f;
+
+    limb_index_map_[motor.limb].push_back(idx);
+    motors.push_back(motor);
+  }
+
+  ensureReceiveBuffer();
+}
+
+std::vector<MotorLayoutEntry> robot::defaultMotorLayout() const
+{
+  return {
+      {"right_arm", "shoulder_yaw", "10010l"},
+      {"right_arm", "shoulder_pitch", "10010l"},
+      {"right_arm", "shoulder_roll", "10010l"},
+      {"right_arm", "elbow_pitch", "6248p"},
+      {"right_arm", "wrist_pitch", "4340"},
+      {"right_arm", "wrist_roll", "4340"},
+      {"right_arm", "wrist_yaw", "4340"},
+      {"left_arm", "shoulder_yaw", "6248p"},
+      {"left_arm", "shoulder_pitch", "6248p"},
+      {"left_arm", "shoulder_roll", "6248p"},
+      {"left_arm", "elbow_pitch", "4340"},
+      {"left_arm", "wrist_pitch", "4340"},
+      {"left_arm", "wrist_roll", "4340"},
+      {"left_arm", "wrist_yaw", "4340"}};
+}
+
+std::vector<MotorLayoutEntry> robot::loadMotorLayout()
+{
+  ros::NodeHandle nh_private("~");
+  XmlRpc::XmlRpcValue param;
+  std::vector<MotorLayoutEntry> layout;
+
+  if (nh_private.getParam("motor_layout", param))
+  {
+    layout = parseLayout(param);
+  }
+  else if (n.getParam(robot_name + "/motor_layout", param))
+  {
+    layout = parseLayout(param);
+  }
+  else if (n.getParam("motor_layout", param))
+  {
+    layout = parseLayout(param);
+  }
+
+  if (layout.empty())
+  {
+    ROS_WARN_STREAM("motor_layout parameter not found or empty. Using default layout for " << robot_name);
+    layout = defaultMotorLayout();
+  }
+  return layout;
+}
+
+std::size_t robot::motorCount() const
+{
+  return motors.size();
 }
 
 void robot::get_motor_data_thread()
-{   
-//ros::Rate ra(100000); 
-  while (ros::ok()&&!stop_thread_)
-  {    
-    if (!serial_motor.isOpen())
+{
+  std::size_t count = 0;
+  while (ros::ok() && !stop_thread_)
+  {
+    if (motors.empty() || receive_buffer_.empty())
     {
-      ROS_WARN("In get_motor_data_thread,motor serial port unopen");
-    }       
-
-  short transition_16=0;  //中间变量
-  uint8_t i=0,check=0, error=1,Receive_Data_Pr[1];  //临时变量，保存下位机数据
-  static int count; //静态变量，用于计数
-  serial_motor.read(Receive_Data_Pr,sizeof(Receive_Data_Pr)); //通过串口读取下位机发送过来的数据
-  
-
-  Receive_Data.rx[count] = Receive_Data_Pr[0];  //串口数据填入数组
-  Receive_Data.Frame_Header = Receive_Data.rx[0]; 
-
-  if(Receive_Data_Pr[0] == FRAME_HEADER || count>0) //确保数组第一个数据为FRAME_HEADER
-      count++;
-  else 
-    count=0;
-  if (count == RECEIVE_DATA_SIZE) {  // 72 when NUM_MOTORS=14
-  count = 0;
-  check = Check_Sum(RECEIVE_DATA_SIZE - 1, READ_DATA_CHECK);
-  if (check == Receive_Data.rx[RECEIVE_DATA_SIZE - 1]) {
-    error = 0;
-  }
-  if (error == 0) {
-    for (int i = 0; i < NUM_MOTORS; ++i) {
-      uint8_t* p = &Receive_Data.rx[1 + i*5];
-      auto& m = motors[i];
-      if      (m.type == "4340")   dm4340_fbdata(m, p);
-      else if (m.type == "4310")   dm4310_fbdata(m, p);
-      else if (m.type == "6006")   dm6006_fbdata(m, p);
-      else if (m.type == "8006")   dm8006_fbdata(m, p);
-      else if (m.type == "6248p")  dm6248p_fbdata(m, p);
-      else if (m.type == "10010l") dm10010l_fbdata(m, p);
-      else                         dm4340_fbdata(m, p); // 默认兜底
+      ros::Duration(0.05).sleep();
+      continue;
     }
 
-  }
-}
-   
-  }
-}
+    if (!serial_motor.isOpen())
+    {
+      ROS_WARN_THROTTLE(1.0, "In get_motor_data_thread, motor serial port unopen");
+      ros::Duration(0.05).sleep();
+      continue;
+    }
 
+    uint8_t byte = 0;
+    try
+    {
+      serial_motor.read(&byte, 1);
+    }
+    catch (serial::IOException& e)
+    {
+      ROS_ERROR_THROTTLE(1.0, "Failed to read from motor serial port: %s", e.what());
+      continue;
+    }
+
+    if (count == 0)
+    {
+      if (byte != FRAME_HEADER)
+      {
+        continue;
+      }
+    }
+
+    receive_buffer_[count++] = byte;
+
+    if (count == receive_buffer_.size())
+    {
+      count = 0;
+      const uint8_t checksum = computeChecksum(receive_buffer_.size() - 1, CheckMode::Receive);
+      if (checksum != receive_buffer_.back())
+      {
+        ROS_WARN_THROTTLE(1.0, "Checksum mismatch while parsing motor feedback");
+        continue;
+      }
+
+      for (std::size_t i = 0; i < motors.size(); ++i)
+      {
+        auto& motor = motors[i];
+        uint8_t* p = receive_buffer_.data() + 1 + i * kFeedbackWordSize;
+        if      (motor.type == "4340")   dm4340_fbdata(motor, p);
+        else if (motor.type == "4310")   dm4310_fbdata(motor, p);
+        else if (motor.type == "6006")   dm6006_fbdata(motor, p);
+        else if (motor.type == "8006")   dm8006_fbdata(motor, p);
+        else if (motor.type == "6248p")  dm6248p_fbdata(motor, p);
+        else if (motor.type == "10010l") dm10010l_fbdata(motor, p);
+        else                               dm4340_fbdata(motor, p);
+      }
+    }
+  }
+}
 
 void robot::publishJointStates()
 {
-  ros::Rate rate(1000); 
+  ros::Rate rate(1000);
   while (ros::ok())
   {
-      sensor_msgs::JointState joint_state_msg;
+    sensor_msgs::JointState joint_state_msg;
 
-      for(int i=0; i<NUM_MOTORS; i++)
-      {    
-          joint_state_msg.name.push_back(motors[i].name);                   
-         
-          joint_state_msg.position.push_back(motors[i].pos);
-          joint_state_msg.velocity.push_back(motors[i].vel);
-          joint_state_msg.effort.push_back(motors[i].tor); 
-      }
+    joint_state_msg.name.reserve(motors.size());
+    joint_state_msg.position.reserve(motors.size());
+    joint_state_msg.velocity.reserve(motors.size());
+    joint_state_msg.effort.reserve(motors.size());
+
+    for (const auto& motor : motors)
+    {
+      joint_state_msg.name.push_back(motor.name);
+      joint_state_msg.position.push_back(motor.pos);
+      joint_state_msg.velocity.push_back(motor.vel);
+      joint_state_msg.effort.push_back(motor.tor);
+    }
 
     joint_state_pub.publish(joint_state_msg);
 
@@ -191,128 +357,151 @@ void robot::publishJointStates()
 }
 
 void robot::send_motor_data()
-{   
-  ros::Time last_time2 = ros::Time::now();
-  for(auto& motor:motors)
-  {  
-    uint16_t pos_tmp, vel_tmp, kp_tmp, kd_tmp, tor_tmp;
-    if(motor.type == "8006")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN4,  P_MAX4,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN4,  V_MAX4,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN4, KP_MAX4, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN4, KD_MAX4, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN4,  T_MAX4,  12);
-    }
-    else if(motor.type == "6006")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN3,  P_MAX3,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN3,  V_MAX3,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN3, KP_MAX3, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN3, KD_MAX3, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN3,  T_MAX3,  12);
-    }
-    else  if(motor.type == "4340")
+{
+  if (motors.empty())
+  {
+    return;
+  }
+
+  for (auto& motor : motors)
+  {
+    uint16_t pos_tmp = 0;
+    uint16_t vel_tmp = 0;
+    uint16_t kp_tmp = 0;
+    uint16_t kd_tmp = 0;
+    uint16_t tor_tmp = 0;
+
+    if (motor.type == "8006")
     {
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN2,  P_MAX2,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN2,  V_MAX2,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN2, KP_MAX2, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN2, KD_MAX2, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN2,  T_MAX2,  12);
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN4,  P_MAX4,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN4,  V_MAX4,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN4, KP_MAX4, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN4, KD_MAX4, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN4,  T_MAX4,  12);
     }
-    else  if(motor.type == "4310")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN1,  P_MAX1,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN1,  V_MAX1,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN1, KP_MAX1, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN1, KD_MAX1, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN1,  T_MAX1,  12);
+    else if (motor.type == "6248p")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN5,  P_MAX5,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN5,  V_MAX5,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN5, KP_MAX5, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN5, KD_MAX5, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN5,  T_MAX5,  12);
     }
-    else  if(motor.type == "6248p")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN5,  P_MAX5,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN5,  V_MAX5,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN5, KP_MAX5, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN5, KD_MAX5, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN5,  T_MAX5,  12);
+    else if (motor.type == "6006")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN3,  P_MAX3,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN3,  V_MAX3,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN3, KP_MAX3, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN3, KD_MAX3, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN3,  T_MAX3,  12);
     }
-    else  if(motor.type == "10010l")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN6,  P_MAX6,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN6,  V_MAX6,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN6, KP_MAX6, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN6, KD_MAX6, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN6,  T_MAX6,  12);
+    else if (motor.type == "4310")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN1,  P_MAX1,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN1,  V_MAX1,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN1, KP_MAX1, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN1, KD_MAX1, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN1,  T_MAX1,  12);
     }
-    Send_Data.tx[0]=FRAME_HEADER; 
-    Send_Data.tx[1]=motor.index;
+    else if (motor.type == "10010l")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN6,  P_MAX6,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN6,  V_MAX6,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN6, KP_MAX6, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN6, KD_MAX6, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN6,  T_MAX6,  12);
+    }
+    else
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN2,  P_MAX2,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN2,  V_MAX2,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN2, KP_MAX2, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN2, KD_MAX2, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN2,  T_MAX2,  12);
+    }
 
-    Send_Data.tx[2] = (pos_tmp >> 8);
-    Send_Data.tx[3] = pos_tmp;
-    Send_Data.tx[4] = (vel_tmp >> 4);
-    Send_Data.tx[5] = ((vel_tmp&0x0F)<<4)|(kp_tmp>>8);
-    Send_Data.tx[6] = kp_tmp;
-    Send_Data.tx[7] = (kd_tmp >> 4);
-    Send_Data.tx[8] = ((kd_tmp&0xF)<<4)|(tor_tmp>>8);
-    Send_Data.tx[9] = tor_tmp;
+    Send_Data.tx[0] = FRAME_HEADER;
+    Send_Data.tx[1] = static_cast<uint8_t>(motor.index);
 
-    Send_Data.tx[10]=Check_Sum(10,SEND_DATA_CHECK);   
-     
+    Send_Data.tx[2] = static_cast<uint8_t>(pos_tmp >> 8);
+    Send_Data.tx[3] = static_cast<uint8_t>(pos_tmp);
+    Send_Data.tx[4] = static_cast<uint8_t>(vel_tmp >> 4);
+    Send_Data.tx[5] = static_cast<uint8_t>(((vel_tmp & 0x0F) << 4) | (kp_tmp >> 8));
+    Send_Data.tx[6] = static_cast<uint8_t>(kp_tmp);
+    Send_Data.tx[7] = static_cast<uint8_t>(kd_tmp >> 4);
+    Send_Data.tx[8] = static_cast<uint8_t>(((kd_tmp & 0x0F) << 4) | (tor_tmp >> 8));
+    Send_Data.tx[9] = static_cast<uint8_t>(tor_tmp);
+
+    Send_Data.tx[10] = Check_Sum(10, SEND_DATA_CHECK);
+
     try
-    { //通过串口向下位机发送数据 
-      serial_motor.write(Send_Data.tx,sizeof(Send_Data.tx));
-    //ROS_INFO("Current time Motor: %f", interval.toSec());
-    }
-    catch (serial::IOException& e)   
     {
-      ROS_ERROR_STREAM("In send_motor_data,Unable to send data through motor serial port"); //If sending data fails, an error message is printed //如果发送数据失败，打印错误信息
+      serial_motor.write(Send_Data.tx.data(), Send_Data.tx.size());
     }
-
-  }  
-        
+    catch (serial::IOException& e)
+    {
+      ROS_ERROR_STREAM("In send_motor_data,Unable to send data through motor serial port: " << e.what());
+    }
+  }
 }
 
-
 void robot::fresh_cmd_motor_data(double pos, double vel,double torque, double kp,double kd,int motor_idx)
-{//更新发给电机的参数、力矩等
-  motors[motor_idx].pos_set = pos;
-  motors[motor_idx].vel_set = vel;
-  motors[motor_idx].tor_set = torque;
-  motors[motor_idx].kp = kp;
-  motors[motor_idx].kd = kd;                
+{
+  if (motor_idx < 0 || static_cast<std::size_t>(motor_idx) >= motors.size())
+  {
+    ROS_WARN_THROTTLE(1.0, "fresh_cmd_motor_data motor index %d out of range", motor_idx);
+    return;
+  }
+  auto& motor = motors[static_cast<std::size_t>(motor_idx)];
+  motor.pos_set = static_cast<float>(pos);
+  motor.vel_set = static_cast<float>(vel);
+  motor.tor_set = static_cast<float>(torque);
+  motor.kp = static_cast<float>(kp);
+  motor.kd = static_cast<float>(kd);
 }
 
 void robot::get_motor_data(double &pos,double &vel,double &torque, int motor_idx)
-{//获取电机反馈的参数、力矩等
-  pos = motors[motor_idx].pos;
-  vel = motors[motor_idx].vel;
-  torque =motors[motor_idx].tor;
+{
+  if (motor_idx < 0 || static_cast<std::size_t>(motor_idx) >= motors.size())
+  {
+    ROS_WARN_THROTTLE(1.0, "get_motor_data motor index %d out of range", motor_idx);
+    pos = 0.0;
+    vel = 0.0;
+    torque = 0.0;
+    return;
+  }
+  const auto& motor = motors[static_cast<std::size_t>(motor_idx)];
+  pos = motor.pos;
+  vel = motor.vel;
+  torque = motor.tor;
 }
 
-/**************************************
-功能: 串口通讯校验函数，数据包n有个字节，第n-1个字节为校验位，第n个字节位帧尾。第1个字节到第n-2个字节数据按位异或的结果与第n-1个字节对比，即为BCC校验
-输入参数： Count_Number：数据包前几个字节加入校验   mode：对发送数据还是接收数据进行校验
-***************************************/
 unsigned char robot::Check_Sum(unsigned char Count_Number,unsigned char mode)
 {
-    unsigned char check_sum=0,k;
+  const CheckMode check_mode = (mode == READ_DATA_CHECK) ? CheckMode::Receive : CheckMode::Send;
+  return computeChecksum(static_cast<std::size_t>(Count_Number), check_mode);
+}
 
-    if(mode==0) //Receive data mode //接收数据模式
+uint8_t robot::computeChecksum(std::size_t count_number, CheckMode mode) const
+{
+  uint8_t check_sum = 0;
+  if (mode == CheckMode::Receive)
+  {
+    const std::size_t max_count = std::min(count_number, receive_buffer_.size());
+    for (std::size_t k = 0; k < max_count; ++k)
     {
-        for(k=0;k<Count_Number;k++)
-        {
-            check_sum=check_sum^Receive_Data.rx[k]; //By bit or by bit //按位异或
-        }
+      check_sum = static_cast<uint8_t>(check_sum ^ receive_buffer_[k]);
     }
-
-    if(mode==1) //Send data mode //发送数据模式
+  }
+  else
+  {
+    const std::size_t max_count = std::min(count_number, Send_Data.tx.size());
+    for (std::size_t k = 0; k < max_count; ++k)
     {
-        for(k=0;k<Count_Number;k++)
-        {
-            check_sum=check_sum^Send_Data.tx[k]; //By bit or by bit //按位异或
-        }
+      check_sum = static_cast<uint8_t>(check_sum ^ Send_Data.tx[k]);
     }
-  return check_sum; //Returns the bitwise XOR result //返回按位异或结果
+  }
+  return check_sum;
 }
 
 void robot::dm4310_fbdata(motor_data_t& moto,uint8_t *data)
@@ -341,8 +530,8 @@ void robot::dm6006_fbdata(motor_data_t& moto,uint8_t *data)
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
   moto.pos = uint_to_float(moto.p_int, P_MIN3, P_MAX3, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN3, V_MAX3, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN3, T_MAX3, 12);  // (-10.0,10.0)
+  moto.vel = uint_to_float(moto.v_int, V_MIN3, V_MAX3, 12); // (-45.0,45.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN3, T_MAX3, 12);  // (-12.0,12.0)
 }
 
 void robot::dm8006_fbdata(motor_data_t& moto,uint8_t *data)
@@ -351,8 +540,8 @@ void robot::dm8006_fbdata(motor_data_t& moto,uint8_t *data)
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
   moto.pos = uint_to_float(moto.p_int, P_MIN4, P_MAX4, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN4, V_MAX4, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN4, T_MAX4, 12);  // (-10.0,10.0)
+  moto.vel = uint_to_float(moto.v_int, V_MIN4, V_MAX4, 12); // (-45.0,45.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN4, T_MAX4, 12);  // (-20.0,20.0)
 }
 
 void robot::dm6248p_fbdata(motor_data_t& moto,uint8_t *data)
@@ -360,9 +549,9 @@ void robot::dm6248p_fbdata(motor_data_t& moto,uint8_t *data)
   moto.p_int=(data[0]<<8)|data[1];
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
-  moto.pos = uint_to_float(moto.p_int, P_MIN5, P_MAX5, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN5, V_MAX5, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN5, T_MAX5, 12);  // (-10.0,10.0)
+  moto.pos = uint_to_float(moto.p_int, P_MIN5, P_MAX5, 16); // (-12.566,12.566)
+  moto.vel = uint_to_float(moto.v_int, V_MIN5, V_MAX5, 12); // (-20.0,20.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN5, T_MAX5, 12);  // (-120.0,120.0)
 }
 
 void robot::dm10010l_fbdata(motor_data_t& moto,uint8_t *data)
@@ -371,27 +560,21 @@ void robot::dm10010l_fbdata(motor_data_t& moto,uint8_t *data)
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
   moto.pos = uint_to_float(moto.p_int, P_MIN6, P_MAX6, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN6, V_MAX6, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN6, T_MAX6, 12);  // (-10.0,10.0)
+  moto.vel = uint_to_float(moto.v_int, V_MIN6, V_MAX6, 12); // (-25.0,25.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN6, T_MAX6, 12);  // (-200.0,200.0)
 }
 
 int16_t robot::float_to_uint(float x_float, float x_min, float x_max, int bits)
 {
-  /* Converts a float to an unsigned int, given range and number of bits */
   float span = x_max - x_min;
   float offset = x_min;
-  return (int16_t)((x_float-offset)*((float)((1<<bits)-1))/span);
+  return static_cast<int16_t>((x_float - offset) * ((static_cast<float>((1 << bits) - 1)) / span));
 }
 
 float robot::uint_to_float(int x_int, float x_min, float x_max, int bits)
 {
-  /* converts unsigned int to float, given range and number of bits */
   float span = x_max - x_min;
-  float offset = x_min;
-  return ((float)x_int)*span/((float)((1<<bits)-1)) + offset;
+  return static_cast<float>(x_int) * span / static_cast<float>((1 << bits) - 1) + x_min;
 }
 
-
-}
-
-
+}  // namespace dmbot_serial

--- a/src/dmbot_serial/src/stm32_motor_bridge.py
+++ b/src/dmbot_serial/src/stm32_motor_bridge.py
@@ -11,9 +11,6 @@ from std_msgs.msg import Float64MultiArray, Float32
 FRAME_HEADER = 0x7B
 PACKET_LENGTH = 11  # 1B头 + 1B id + 8B payload + 1B XOR
 
-# ========= 新增：参数化 =========
-NUM_MOTORS = rospy.get_param("/stm32_motor_bridge/num_motors", 14)
-# ==============================
 
 def xor_checksum(data_bytes):
     c = 0
@@ -21,8 +18,9 @@ def xor_checksum(data_bytes):
         c ^= b
     return c & 0xFF
 
-def build_packet(motor_id, payload_8bytes):
-    assert 0 <= motor_id < NUM_MOTORS, "motor_id 越界"
+
+def build_packet(motor_id, payload_8bytes, num_motors):
+    assert 0 <= motor_id < num_motors, "motor_id 越界"
     if len(payload_8bytes) != 8:
         raise ValueError("payload 必须 8 字节")
     buf = bytearray(10)
@@ -32,51 +30,57 @@ def build_packet(motor_id, payload_8bytes):
     chksum = xor_checksum(buf)
     return bytes(buf) + bytes([chksum])
 
-def clamp_int16(v): return max(-32768, min(32767, int(round(v))))
+
+def clamp_int16(v):
+    return max(-32768, min(32767, int(round(v))))
+
 
 def encode_pd_q15(pos, vel, kp, kd, scale=1000, big_endian=True):
     # 注意：如果下位机忽略 vel，你也可以置 0
     p = clamp_int16(pos * scale)
     v = clamp_int16(vel * scale)
-    kpp = clamp_int16(kp  * scale)
-    kdd = clamp_int16(kd  * scale)
+    kpp = clamp_int16(kp * scale)
+    kdd = clamp_int16(kd * scale)
     vals = [p, v, kpp, kdd]
     b = bytearray(8)
     for i, val in enumerate(vals):
         if big_endian:
-            b[2*i]   = (val >> 8) & 0xFF
-            b[2*i+1] =  val       & 0xFF
+            b[2 * i] = (val >> 8) & 0xFF
+            b[2 * i + 1] = val & 0xFF
         else:
-            b[2*i]   =  val       & 0xFF
-            b[2*i+1] = (val >> 8) & 0xFF
+            b[2 * i] = val & 0xFF
+            b[2 * i + 1] = (val >> 8) & 0xFF
     return b
+
 
 class Stm32Bridge(object):
     def __init__(self):
-        self.port   = rospy.get_param("~port", "/dev/mcu_rightarm")
-        self.baud   = int(rospy.get_param("~baud", 921600))       # 改成 921600
-        self.rate_hz= float(rospy.get_param("~rate", 100.0))
-        self.mode   = rospy.get_param("~mode", "pd_q15")
-        self.scale  = float(rospy.get_param("~scale", 1000.0))
+        self.robot_name = rospy.get_param("~robot_name", rospy.get_param("robot_name", "ludan"))
+        self.num_motors = self._resolve_motor_count()
+        rospy.loginfo("stm32_motor_bridge: %s using %d motors", self.robot_name, self.num_motors)
+
+        self.port = rospy.get_param("~port", "/dev/mcu_rightarm")
+        self.baud = int(rospy.get_param("~baud", 921600))
+        self.rate_hz = float(rospy.get_param("~rate", 100.0))
+        self.mode = rospy.get_param("~mode", "pd_q15")
+        self.scale = float(rospy.get_param("~scale", 1000.0))
         self.big_endian = bool(rospy.get_param("~big_endian", True))
 
-        # /hybrid_cmd 长度 = 5*NUM_MOTORS
-        self.cmd = [0.0] * (5 * NUM_MOTORS)
+        self.cmd = [0.0] * (5 * self.num_motors)
         self.cmd_lock = threading.Lock()
         self.last_cmd_time = 0.0
         self.timeout = float(rospy.get_param("~timeout", 0.2))
 
         self.emergency_stop = False
 
-        # 方向映射长度改成 NUM_MOTORS（按你实际填充）
-        default_dir = [1]*NUM_MOTORS
-        # 例：原来 10 路是 [ 1,1,-1,1,1, -1,1,-1,-1,-1 ]
-        # 你可以在参数服务器覆盖，也可以这里直接写 14 路的表
-        self.direction = rospy.get_param("~direction", default_dir)
+        default_dir = [1] * self.num_motors
+        direction_param = rospy.get_param("~direction", default_dir)
+        if len(direction_param) < self.num_motors:
+            direction_param = list(direction_param) + [1] * (self.num_motors - len(direction_param))
+        self.direction = list(direction_param[:self.num_motors])
 
-        # raw8 的默认 payload
         self.raw_payload_default = [0x7F, 0xFF, 0x84, 0x30, 0x00, 0x33, 0x37, 0xFF]
-        self.raw_payloads = [bytearray(self.raw_payload_default) for _ in range(NUM_MOTORS)]
+        self.raw_payloads = [bytearray(self.raw_payload_default) for _ in range(self.num_motors)]
 
         self.ser = serial.Serial(self.port, self.baud, timeout=0.05)
         rospy.loginfo("stm32_motor_bridge 串口已打开 %s @ %d", self.port, self.baud)
@@ -84,8 +88,7 @@ class Stm32Bridge(object):
         rospy.Subscriber("/hybrid_cmd", Float64MultiArray, self.hybrid_cb, queue_size=1)
         rospy.Subscriber("/emergency_stop", Float32, self.emg_cb, queue_size=1)
 
-        # raw8 订阅也扩到 NUM_MOTORS
-        for mid in range(NUM_MOTORS):
+        for mid in range(self.num_motors):
             rospy.Subscriber(f"/stm32/raw8/motor{mid}", Float64MultiArray,
                              lambda msg, i=mid: self.raw8_cb(i, msg), queue_size=1)
 
@@ -93,9 +96,34 @@ class Stm32Bridge(object):
         self.th = threading.Thread(target=self.loop, daemon=True)
         self.th.start()
 
+    @staticmethod
+    def _count_from_layout(layout):
+        return len(layout) if isinstance(layout, list) and len(layout) > 0 else 0
+
+    def _resolve_motor_count(self):
+        layout = rospy.get_param("~motor_layout", None)
+        count = self._count_from_layout(layout)
+        if count:
+            return count
+
+        if self.robot_name:
+            global_layout = rospy.get_param(f"/{self.robot_name}/motor_layout", None)
+            count = self._count_from_layout(global_layout)
+            if count:
+                rospy.set_param("~motor_layout", global_layout)
+                return count
+
+        fallback_layout = rospy.get_param("/motor_layout", None)
+        count = self._count_from_layout(fallback_layout)
+        if count:
+            rospy.set_param("~motor_layout", fallback_layout)
+            return count
+
+        return int(rospy.get_param("~num_motors", rospy.get_param("/stm32_motor_bridge/num_motors", 14)))
+
     def hybrid_cb(self, msg: Float64MultiArray):
         data = list(msg.data)
-        need = 5 * NUM_MOTORS
+        need = 5 * self.num_motors
         if len(data) != need:
             rospy.logwarn_throttle(1.0, "/hybrid_cmd 长度=%d（需 %d），忽略", len(data), need)
             return
@@ -108,6 +136,9 @@ class Stm32Bridge(object):
         rospy.logwarn("收到急停: %s", self.emergency_stop)
 
     def raw8_cb(self, motor_id, msg: Float64MultiArray):
+        if not (0 <= motor_id < self.num_motors):
+            rospy.logwarn_throttle(1.0, "raw8 motor id %d 越界", motor_id)
+            return
         arr = msg.data
         if len(arr) != 8:
             rospy.logwarn("raw8 电机 %d 长度=%d(需8)，忽略", motor_id, len(arr))
@@ -128,14 +159,12 @@ class Stm32Bridge(object):
             with self.cmd_lock:
                 d = self.cmd[:]
 
-            # 切片都按 NUM_MOTORS
-            pos = d[0:NUM_MOTORS]
-            vel = d[NUM_MOTORS:2*NUM_MOTORS]
-            kp  = d[2*NUM_MOTORS:3*NUM_MOTORS]
-            kd  = d[3*NUM_MOTORS:4*NUM_MOTORS]
-            # tau = d[4*NUM_MOTORS:5*NUM_MOTORS]  # 如固件不用可忽略
+            pos = d[0:self.num_motors]
+            vel = d[self.num_motors:2 * self.num_motors]
+            kp = d[2 * self.num_motors:3 * self.num_motors]
+            kd = d[3 * self.num_motors:4 * self.num_motors]
 
-            for mid in range(NUM_MOTORS):
+            for mid in range(self.num_motors):
                 if self.mode == "raw8":
                     payload = self.raw_payloads[mid]
                 else:
@@ -145,7 +174,7 @@ class Stm32Bridge(object):
                     kdd = kd[mid]
                     payload = encode_pd_q15(p, v, kpp, kdd, scale=self.scale, big_endian=self.big_endian)
 
-                pkt = build_packet(mid, payload)
+                pkt = build_packet(mid, payload, self.num_motors)
                 try:
                     self.ser.write(pkt)
                 except Exception as e:
@@ -158,11 +187,12 @@ class Stm32Bridge(object):
         self.run = False
         try:
             self.th.join(timeout=1.0)
-        except:
+        except Exception:
             pass
         if self.ser and self.ser.is_open:
             self.ser.close()
         rospy.loginfo("stm32_motor_bridge 已关闭")
+
 
 if __name__ == "__main__":
     rospy.init_node("stm32_motor_bridge")

--- a/src/dmbot_serial/src/test_motor.cpp
+++ b/src/dmbot_serial/src/test_motor.cpp
@@ -4,8 +4,6 @@
 #include <vector>
 #include <iostream>
 
-static constexpr int N = NUM_MOTORS;  // 14
-
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "test_motor");
@@ -25,27 +23,33 @@ int main(int argc, char **argv)
 
   // 创建上位机串口接口
   dmbot_serial::robot rb;
+  const std::size_t motor_count = rb.motorCount();
+  if (motor_count == 0)
+  {
+    ROS_ERROR("未配置任何电机，退出 test_motor");
+    return 1;
+  }
 
-  std::vector<double> pos_cmd(N, 0.0), vel_cmd(N, 0.0), tor_cmd(N, 0.0);
+  std::vector<double> pos_cmd(motor_count, 0.0), vel_cmd(motor_count, 0.0), tor_cmd(motor_count, 0.0);
 
   const double two_pi = 2.0 * M_PI;
   const double dt = 1.0 / 200.0;
   double t = 0.0;
 
-  ROS_INFO("test_motor running with N=%d, pos_amp=%.3f rad, freq=%.3f Hz, kp=%.3f, kd=%.3f",
-           N, pos_amp, freq, kp, kd);
+  ROS_INFO("test_motor running with N=%zu, pos_amp=%.3f rad, freq=%.3f Hz, kp=%.3f, kd=%.3f",
+           motor_count, pos_amp, freq, kp, kd);
   ROS_INFO("默认不动，若要小幅测试请传参：_pos_amp:=0.05 _kp:=2.0 _kd:=0.1");
 
   while (ros::ok())
   {
-    // 生成 14 路命令（简单正弦，带相位错开，便于识别）
-    for (int i = 0; i < N; ++i)
+    // 生成多路命令（简单正弦，带相位错开，便于识别）
+    for (std::size_t i = 0; i < motor_count; ++i)
     {
-      double phase = (two_pi * i) / N;
+      double phase = (two_pi * static_cast<double>(i)) / static_cast<double>(motor_count);
       pos_cmd[i] = pos_amp * std::sin(two_pi * freq * t + phase);
       vel_cmd[i] = 0.0;   // 如固件需要也可给导数
       tor_cmd[i] = 0.0;
-      rb.fresh_cmd_motor_data(pos_cmd[i], vel_cmd[i], tor_cmd[i], kp, kd, i);
+      rb.fresh_cmd_motor_data(pos_cmd[i], vel_cmd[i], tor_cmd[i], kp, kd, static_cast<int>(i));
     }
 
     // 下发给 STM32
@@ -53,10 +57,18 @@ int main(int argc, char **argv)
 
     // 可选：打印少量反馈
     if (static_cast<int>(t*10) % 10 == 0) { // 约每 0.1s 打印一次
-      double p0,v0,t0, p7,v7,t7, p13,v13,t13;
+      double p0 = 0.0, v0 = 0.0, t0 = 0.0;
+      double p7 = 0.0, v7 = 0.0, t7 = 0.0;
+      double p13 = 0.0, v13 = 0.0, t13 = 0.0;
       rb.get_motor_data(p0,v0,t0,0);
-      rb.get_motor_data(p7,v7,t7,7);
-      rb.get_motor_data(p13,v13,t13,13);
+      if (motor_count > 7)
+      {
+        rb.get_motor_data(p7,v7,t7,7);
+      }
+      if (motor_count > 13)
+      {
+        rb.get_motor_data(p13,v13,t13,13);
+      }
       ROS_INFO_THROTTLE(0.5, "m0 pos=%.3f, m7 pos=%.3f, m13 pos=%.3f", p0, p7, p13);
     }
 

--- a/src/dmbot_serial_leftarm/src/robot_connect.cpp
+++ b/src/dmbot_serial_leftarm/src/robot_connect.cpp
@@ -1,188 +1,354 @@
 #include <dmbot_serial/robot_connect.h>
 
+#include <algorithm>
+#include <cctype>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <ros/console.h>
+#include <xmlrpcpp/XmlRpcValue.h>
 
 namespace dmbot_serial
 {
+namespace
+{
+const std::vector<std::string> kCanonicalLimbs = {"left_arm", "right_arm", "left_leg", "right_leg", "waist", "neck"};
+
+std::string normalizeToken(const std::string& raw)
+{
+  std::string result;
+  result.reserve(raw.size());
+  char last = '\0';
+  for (char c : raw)
+  {
+    const unsigned char uc = static_cast<unsigned char>(c);
+    if (std::isalnum(uc) != 0)
+    {
+      result.push_back(static_cast<char>(std::tolower(uc)));
+      last = result.back();
+    }
+    else if (last != '_')
+    {
+      result.push_back('_');
+      last = '_';
+    }
+  }
+  while (!result.empty() && result.back() == '_')
+  {
+    result.pop_back();
+  }
+  if (result.empty())
+  {
+    return "joint";
+  }
+  return result;
+}
+
+std::string buildMotorName(const std::string& robot, const std::string& limb, const std::string& joint,
+                           std::map<std::string, int>& usage)
+{
+  std::string base = robot + "_" + limb + "_" + joint;
+  std::string candidate = base;
+  int index = 1;
+  while (usage.count(candidate) != 0)
+  {
+    candidate = base + "_" + std::to_string(++index);
+  }
+  usage[candidate] = 1;
+  return candidate;
+}
+
+std::vector<MotorLayoutEntry> parseLayout(const XmlRpc::XmlRpcValue& param)
+{
+  std::vector<MotorLayoutEntry> layout;
+  if (param.getType() != XmlRpc::XmlRpcValue::TypeArray)
+  {
+    return layout;
+  }
+  layout.reserve(param.size());
+  for (int i = 0; i < param.size(); ++i)
+  {
+    if (param[i].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      continue;
+    }
+    MotorLayoutEntry entry;
+    if (param[i].hasMember("limb") && param[i]["limb"].getType() == XmlRpc::XmlRpcValue::TypeString)
+    {
+      entry.limb = static_cast<std::string>(param[i]["limb"]);
+    }
+    if (param[i].hasMember("joint") && param[i]["joint"].getType() == XmlRpc::XmlRpcValue::TypeString)
+    {
+      entry.joint = static_cast<std::string>(param[i]["joint"]);
+    }
+    if (param[i].hasMember("type") && param[i]["type"].getType() == XmlRpc::XmlRpcValue::TypeString)
+    {
+      entry.type = static_cast<std::string>(param[i]["type"]);
+    }
+    if (!entry.limb.empty())
+    {
+      layout.push_back(entry);
+    }
+  }
+  return layout;
+}
+}  // namespace
+
 robot::robot()
 {
+  ros::NodeHandle nh_private("~");
+  nh_private.param<std::string>("robot_name", robot_name, std::string("ludan"));
+  n.param("robot_name", robot_name, robot_name);
+  nh_private.param<std::string>("port", motor_serial_port, std::string("/dev/mcu_leftarm"));
+  nh_private.param("baud", motor_seial_baud, 921600);
 
-  n.param("port", motor_serial_port, std::string("/dev/mcu_leftarm")); 
-  n.param("baud", motor_seial_baud, 921600);
-  
-  int i=0;
-  for(auto& motor:motors)
-  {
-      motor.name = "Motor_" + std::to_string(i);   
-      motor.pos = 0.0f;
-      motor.vel = 0.0f;
-      motor.tor = 0.0f;
-      motor.tor_set = 0.0f;
-      motor.pos_set = 0.0f;
-      motor.vel_set = 0.0f;
-      motor.kp = 0.0f;
-      motor.kd = 0.0f;
-      motor.index=i;
-      i++;
-  }
-  motors[0].type = "10010l";
-  motors[1].type = "10010l";
-  motors[2].type = "10010l";
-  motors[3].type = "6248p";                
-  motors[4].type = "4340";
-  motors[5].type = "4340";   
-  motors[6].type = "4340";
-  
-  // motors[7].type = "10010l";
-  // motors[8].type = "10010l";
-  // motors[9].type = "10010l";                
-  // motors[10].type = "6248p";
-  // motors[11].type = "4340";
-  // motors[12].type = "4340";                
-  // motors[13].type = "4340";
+  initializeMotorConfiguration(loadMotorLayout());
+  ensureReceiveBuffer();
 
-    
-  motors[7].type = "6248p";
-  motors[8].type = "6248p";
-  motors[9].type = "6248p";                
-  motors[10].type = "4340";
-  motors[11].type = "4340";
-  motors[12].type = "4340";                
-  motors[13].type = "4340";
-   
-  init_motor_serial();//初始化串口
+  init_motor_serial();
 
   rec_thread = std::thread(&robot::get_motor_data_thread, this);
-  
-  joint_state_pub = n.advertise<sensor_msgs::JointState>("joint_states", 10);   
- // pub_thread = std::thread(&robot::publishJointStates, this);
+
+  joint_state_pub = n.advertise<sensor_msgs::JointState>("joint_states", 10);
 
   ros::Duration(2.0).sleep();
 
-  ROS_INFO("robot init complete");
-
+  ROS_INFO_STREAM(robot_name << " robot init complete. configured motors: " << motors.size());
 }
+
 robot::~robot()
-{   
-   for(int i=0;i<NUM_MOTORS;i++)
+{
+  for (std::size_t i = 0; i < motors.size(); ++i)
   {
-    fresh_cmd_motor_data(0.0, 0.0, 0.0, 0.0, 0.0, i); //更新发给电机的参数、力矩等
+    fresh_cmd_motor_data(0.0, 0.0, 0.0, 0.0, 0.0, static_cast<int>(i));
   }
-  
+
   send_motor_data();
 
   stop_thread_ = true;
 
-  if(rec_thread.joinable())
+  if (rec_thread.joinable())
   {
-    rec_thread.join(); 
+    rec_thread.join();
   }
   if (serial_motor.isOpen())
   {
-    serial_motor.close(); 
+    serial_motor.close();
   }
-  
- // if(pub_thread.joinable())
-  //{
- //     pub_thread.join(); 
-  //}
-
 }
 
 void robot::init_motor_serial()
-{         
-    try
-    {
-      serial_motor.setPort(motor_serial_port);
-      serial_motor.setBaudrate(motor_seial_baud);
-      serial_motor.setFlowcontrol(serial::flowcontrol_none);
-      serial_motor.setParity(serial::parity_none); //default is parity_none
-      serial_motor.setStopbits(serial::stopbits_one);
-      serial_motor.setBytesize(serial::eightbits);
-      serial::Timeout time_out = serial::Timeout::simpleTimeout(20);
-      serial_motor.setTimeout(time_out);
-      serial_motor.open();
-    } 
-    catch (serial::IOException &e)  // 抓取异常
-    {
-        ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
-        exit(0);
-    }
-    if (serial_motor.isOpen())
-    {
-        ROS_INFO_STREAM("In single initialization,Motor Serial Port initialized");
-    }
-    else
-    {
-        ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
-        exit(0);
-    }
-   
+{
+  try
+  {
+    serial_motor.setPort(motor_serial_port);
+    serial_motor.setBaudrate(motor_seial_baud);
+    serial_motor.setFlowcontrol(serial::flowcontrol_none);
+    serial_motor.setParity(serial::parity_none);
+    serial_motor.setStopbits(serial::stopbits_one);
+    serial_motor.setBytesize(serial::eightbits);
+    serial::Timeout time_out = serial::Timeout::simpleTimeout(20);
+    serial_motor.setTimeout(time_out);
+    serial_motor.open();
+  }
+  catch (serial::IOException& /*e*/)
+  {
+    ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
+    throw;
+  }
+  if (serial_motor.isOpen())
+  {
+    ROS_INFO_STREAM("In single initialization,Motor Serial Port initialized");
+  }
+  else
+  {
+    ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
+    throw std::runtime_error("Unable to open motor serial port");
+  }
+}
+
+void robot::ensureReceiveBuffer()
+{
+  const std::size_t expected = motors.empty() ? 0 : (1 + motors.size() * kFeedbackWordSize + 1);
+  receive_buffer_.assign(expected, 0);
+}
+
+void robot::initializeMotorConfiguration(const std::vector<MotorLayoutEntry>& layout)
+{
+  motors.clear();
+  limb_index_map_.clear();
+  for (const auto& limb : kCanonicalLimbs)
+  {
+    limb_index_map_[normalizeToken(limb)] = {};
+  }
+
+  motors.reserve(layout.size());
+  std::map<std::string, int> name_usage;
+
+  for (std::size_t idx = 0; idx < layout.size(); ++idx)
+  {
+    motor_data_t motor{};
+    motor.index = static_cast<int>(idx);
+    motor.limb = normalizeToken(layout[idx].limb);
+    const std::string joint_token = layout[idx].joint.empty() ? ("joint_" + std::to_string(idx + 1)) : layout[idx].joint;
+    motor.joint = normalizeToken(joint_token);
+    motor.type = layout[idx].type.empty() ? "4340" : layout[idx].type;
+    motor.name = buildMotorName(robot_name, motor.limb, motor.joint, name_usage);
+
+    motor.pos = 0.0f;
+    motor.vel = 0.0f;
+    motor.tor = 0.0f;
+    motor.tor_set = 0.0f;
+    motor.pos_set = 0.0f;
+    motor.vel_set = 0.0f;
+    motor.kp = 0.0f;
+    motor.kd = 0.0f;
+
+    limb_index_map_[motor.limb].push_back(idx);
+    motors.push_back(motor);
+  }
+
+  ensureReceiveBuffer();
+}
+
+std::vector<MotorLayoutEntry> robot::defaultMotorLayout() const
+{
+  return {
+      {"right_arm", "shoulder_yaw", "10010l"},
+      {"right_arm", "shoulder_pitch", "10010l"},
+      {"right_arm", "shoulder_roll", "10010l"},
+      {"right_arm", "elbow_pitch", "6248p"},
+      {"right_arm", "wrist_pitch", "4340"},
+      {"right_arm", "wrist_roll", "4340"},
+      {"right_arm", "wrist_yaw", "4340"},
+      {"left_arm", "shoulder_yaw", "6248p"},
+      {"left_arm", "shoulder_pitch", "6248p"},
+      {"left_arm", "shoulder_roll", "6248p"},
+      {"left_arm", "elbow_pitch", "4340"},
+      {"left_arm", "wrist_pitch", "4340"},
+      {"left_arm", "wrist_roll", "4340"},
+      {"left_arm", "wrist_yaw", "4340"}};
+}
+
+std::vector<MotorLayoutEntry> robot::loadMotorLayout()
+{
+  ros::NodeHandle nh_private("~");
+  XmlRpc::XmlRpcValue param;
+  std::vector<MotorLayoutEntry> layout;
+
+  if (nh_private.getParam("motor_layout", param))
+  {
+    layout = parseLayout(param);
+  }
+  else if (n.getParam(robot_name + "/motor_layout", param))
+  {
+    layout = parseLayout(param);
+  }
+  else if (n.getParam("motor_layout", param))
+  {
+    layout = parseLayout(param);
+  }
+
+  if (layout.empty())
+  {
+    ROS_WARN_STREAM("motor_layout parameter not found or empty. Using default layout for " << robot_name);
+    layout = defaultMotorLayout();
+  }
+  return layout;
+}
+
+std::size_t robot::motorCount() const
+{
+  return motors.size();
 }
 
 void robot::get_motor_data_thread()
-{   
-//ros::Rate ra(100000); 
-  while (ros::ok()&&!stop_thread_)
-  {    
-    if (!serial_motor.isOpen())
+{
+  std::size_t count = 0;
+  while (ros::ok() && !stop_thread_)
+  {
+    if (motors.empty() || receive_buffer_.empty())
     {
-      ROS_WARN("In get_motor_data_thread,motor serial port unopen");
-    }       
-
-  short transition_16=0;  //中间变量
-  uint8_t i=0,check=0, error=1,Receive_Data_Pr[1];  //临时变量，保存下位机数据
-  static int count; //静态变量，用于计数
-  serial_motor.read(Receive_Data_Pr,sizeof(Receive_Data_Pr)); //通过串口读取下位机发送过来的数据
-  
-
-  Receive_Data.rx[count] = Receive_Data_Pr[0];  //串口数据填入数组
-  Receive_Data.Frame_Header = Receive_Data.rx[0]; 
-
-  if(Receive_Data_Pr[0] == FRAME_HEADER || count>0) //确保数组第一个数据为FRAME_HEADER
-      count++;
-  else 
-    count=0;
-  if (count == RECEIVE_DATA_SIZE) {  // 72 when NUM_MOTORS=14
-  count = 0;
-  check = Check_Sum(RECEIVE_DATA_SIZE - 1, READ_DATA_CHECK);
-  if (check == Receive_Data.rx[RECEIVE_DATA_SIZE - 1]) {
-    error = 0;
-  }
-  if (error == 0) {
-    for (int i = 0; i < NUM_MOTORS; ++i) {
-      uint8_t* p = &Receive_Data.rx[1 + i*5];
-      auto& m = motors[i];
-      if      (m.type == "4340")   dm4340_fbdata(m, p);
-      else if (m.type == "4310")   dm4310_fbdata(m, p);
-      else if (m.type == "6006")   dm6006_fbdata(m, p);
-      else if (m.type == "8006")   dm8006_fbdata(m, p);
-      else if (m.type == "6248p")  dm6248p_fbdata(m, p);
-      else if (m.type == "10010l") dm10010l_fbdata(m, p);
-      else                         dm4340_fbdata(m, p); // 默认兜底
+      ros::Duration(0.05).sleep();
+      continue;
     }
 
-  }
-}
-   
-  }
-}
+    if (!serial_motor.isOpen())
+    {
+      ROS_WARN_THROTTLE(1.0, "In get_motor_data_thread, motor serial port unopen");
+      ros::Duration(0.05).sleep();
+      continue;
+    }
 
+    uint8_t byte = 0;
+    try
+    {
+      serial_motor.read(&byte, 1);
+    }
+    catch (serial::IOException& e)
+    {
+      ROS_ERROR_THROTTLE(1.0, "Failed to read from motor serial port: %s", e.what());
+      continue;
+    }
+
+    if (count == 0)
+    {
+      if (byte != FRAME_HEADER)
+      {
+        continue;
+      }
+    }
+
+    receive_buffer_[count++] = byte;
+
+    if (count == receive_buffer_.size())
+    {
+      count = 0;
+      const uint8_t checksum = computeChecksum(receive_buffer_.size() - 1, CheckMode::Receive);
+      if (checksum != receive_buffer_.back())
+      {
+        ROS_WARN_THROTTLE(1.0, "Checksum mismatch while parsing motor feedback");
+        continue;
+      }
+
+      for (std::size_t i = 0; i < motors.size(); ++i)
+      {
+        auto& motor = motors[i];
+        uint8_t* p = receive_buffer_.data() + 1 + i * kFeedbackWordSize;
+        if      (motor.type == "4340")   dm4340_fbdata(motor, p);
+        else if (motor.type == "4310")   dm4310_fbdata(motor, p);
+        else if (motor.type == "6006")   dm6006_fbdata(motor, p);
+        else if (motor.type == "8006")   dm8006_fbdata(motor, p);
+        else if (motor.type == "6248p")  dm6248p_fbdata(motor, p);
+        else if (motor.type == "10010l") dm10010l_fbdata(motor, p);
+        else                               dm4340_fbdata(motor, p);
+      }
+    }
+  }
+}
 
 void robot::publishJointStates()
 {
-  ros::Rate rate(1000); 
+  ros::Rate rate(1000);
   while (ros::ok())
   {
-      sensor_msgs::JointState joint_state_msg;
+    sensor_msgs::JointState joint_state_msg;
 
-      for(int i=0; i<NUM_MOTORS; i++)
-      {    
-          joint_state_msg.name.push_back(motors[i].name);                   
-         
-          joint_state_msg.position.push_back(motors[i].pos);
-          joint_state_msg.velocity.push_back(motors[i].vel);
-          joint_state_msg.effort.push_back(motors[i].tor); 
-      }
+    joint_state_msg.name.reserve(motors.size());
+    joint_state_msg.position.reserve(motors.size());
+    joint_state_msg.velocity.reserve(motors.size());
+    joint_state_msg.effort.reserve(motors.size());
+
+    for (const auto& motor : motors)
+    {
+      joint_state_msg.name.push_back(motor.name);
+      joint_state_msg.position.push_back(motor.pos);
+      joint_state_msg.velocity.push_back(motor.vel);
+      joint_state_msg.effort.push_back(motor.tor);
+    }
 
     joint_state_pub.publish(joint_state_msg);
 
@@ -191,128 +357,151 @@ void robot::publishJointStates()
 }
 
 void robot::send_motor_data()
-{   
-  ros::Time last_time2 = ros::Time::now();
-  for(auto& motor:motors)
-  {  
-    uint16_t pos_tmp, vel_tmp, kp_tmp, kd_tmp, tor_tmp;
-    if(motor.type == "8006")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN4,  P_MAX4,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN4,  V_MAX4,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN4, KP_MAX4, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN4, KD_MAX4, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN4,  T_MAX4,  12);
-    }
-    else if(motor.type == "6006")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN3,  P_MAX3,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN3,  V_MAX3,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN3, KP_MAX3, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN3, KD_MAX3, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN3,  T_MAX3,  12);
-    }
-    else  if(motor.type == "4340")
+{
+  if (motors.empty())
+  {
+    return;
+  }
+
+  for (auto& motor : motors)
+  {
+    uint16_t pos_tmp = 0;
+    uint16_t vel_tmp = 0;
+    uint16_t kp_tmp = 0;
+    uint16_t kd_tmp = 0;
+    uint16_t tor_tmp = 0;
+
+    if (motor.type == "8006")
     {
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN2,  P_MAX2,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN2,  V_MAX2,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN2, KP_MAX2, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN2, KD_MAX2, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN2,  T_MAX2,  12);
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN4,  P_MAX4,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN4,  V_MAX4,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN4, KP_MAX4, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN4, KD_MAX4, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN4,  T_MAX4,  12);
     }
-    else  if(motor.type == "4310")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN1,  P_MAX1,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN1,  V_MAX1,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN1, KP_MAX1, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN1, KD_MAX1, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN1,  T_MAX1,  12);
+    else if (motor.type == "6248p")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN5,  P_MAX5,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN5,  V_MAX5,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN5, KP_MAX5, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN5, KD_MAX5, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN5,  T_MAX5,  12);
     }
-    else  if(motor.type == "6248p")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN5,  P_MAX5,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN5,  V_MAX5,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN5, KP_MAX5, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN5, KD_MAX5, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN5,  T_MAX5,  12);
+    else if (motor.type == "6006")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN3,  P_MAX3,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN3,  V_MAX3,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN3, KP_MAX3, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN3, KD_MAX3, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN3,  T_MAX3,  12);
     }
-    else  if(motor.type == "10010l")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN6,  P_MAX6,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN6,  V_MAX6,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN6, KP_MAX6, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN6, KD_MAX6, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN6,  T_MAX6,  12);
+    else if (motor.type == "4310")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN1,  P_MAX1,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN1,  V_MAX1,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN1, KP_MAX1, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN1, KD_MAX1, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN1,  T_MAX1,  12);
     }
-    Send_Data.tx[0]=FRAME_HEADER; 
-    Send_Data.tx[1]=motor.index;
+    else if (motor.type == "10010l")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN6,  P_MAX6,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN6,  V_MAX6,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN6, KP_MAX6, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN6, KD_MAX6, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN6,  T_MAX6,  12);
+    }
+    else
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN2,  P_MAX2,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN2,  V_MAX2,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN2, KP_MAX2, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN2, KD_MAX2, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN2,  T_MAX2,  12);
+    }
 
-    Send_Data.tx[2] = (pos_tmp >> 8);
-    Send_Data.tx[3] = pos_tmp;
-    Send_Data.tx[4] = (vel_tmp >> 4);
-    Send_Data.tx[5] = ((vel_tmp&0x0F)<<4)|(kp_tmp>>8);
-    Send_Data.tx[6] = kp_tmp;
-    Send_Data.tx[7] = (kd_tmp >> 4);
-    Send_Data.tx[8] = ((kd_tmp&0xF)<<4)|(tor_tmp>>8);
-    Send_Data.tx[9] = tor_tmp;
+    Send_Data.tx[0] = FRAME_HEADER;
+    Send_Data.tx[1] = static_cast<uint8_t>(motor.index);
 
-    Send_Data.tx[10]=Check_Sum(10,SEND_DATA_CHECK);   
-     
+    Send_Data.tx[2] = static_cast<uint8_t>(pos_tmp >> 8);
+    Send_Data.tx[3] = static_cast<uint8_t>(pos_tmp);
+    Send_Data.tx[4] = static_cast<uint8_t>(vel_tmp >> 4);
+    Send_Data.tx[5] = static_cast<uint8_t>(((vel_tmp & 0x0F) << 4) | (kp_tmp >> 8));
+    Send_Data.tx[6] = static_cast<uint8_t>(kp_tmp);
+    Send_Data.tx[7] = static_cast<uint8_t>(kd_tmp >> 4);
+    Send_Data.tx[8] = static_cast<uint8_t>(((kd_tmp & 0x0F) << 4) | (tor_tmp >> 8));
+    Send_Data.tx[9] = static_cast<uint8_t>(tor_tmp);
+
+    Send_Data.tx[10] = Check_Sum(10, SEND_DATA_CHECK);
+
     try
-    { //通过串口向下位机发送数据 
-      serial_motor.write(Send_Data.tx,sizeof(Send_Data.tx));
-    //ROS_INFO("Current time Motor: %f", interval.toSec());
-    }
-    catch (serial::IOException& e)   
     {
-      ROS_ERROR_STREAM("In send_motor_data,Unable to send data through motor serial port"); //If sending data fails, an error message is printed //如果发送数据失败，打印错误信息
+      serial_motor.write(Send_Data.tx.data(), Send_Data.tx.size());
     }
-
-  }  
-        
+    catch (serial::IOException& e)
+    {
+      ROS_ERROR_STREAM("In send_motor_data,Unable to send data through motor serial port: " << e.what());
+    }
+  }
 }
 
-
 void robot::fresh_cmd_motor_data(double pos, double vel,double torque, double kp,double kd,int motor_idx)
-{//更新发给电机的参数、力矩等
-  motors[motor_idx].pos_set = pos;
-  motors[motor_idx].vel_set = vel;
-  motors[motor_idx].tor_set = torque;
-  motors[motor_idx].kp = kp;
-  motors[motor_idx].kd = kd;                
+{
+  if (motor_idx < 0 || static_cast<std::size_t>(motor_idx) >= motors.size())
+  {
+    ROS_WARN_THROTTLE(1.0, "fresh_cmd_motor_data motor index %d out of range", motor_idx);
+    return;
+  }
+  auto& motor = motors[static_cast<std::size_t>(motor_idx)];
+  motor.pos_set = static_cast<float>(pos);
+  motor.vel_set = static_cast<float>(vel);
+  motor.tor_set = static_cast<float>(torque);
+  motor.kp = static_cast<float>(kp);
+  motor.kd = static_cast<float>(kd);
 }
 
 void robot::get_motor_data(double &pos,double &vel,double &torque, int motor_idx)
-{//获取电机反馈的参数、力矩等
-  pos = motors[motor_idx].pos;
-  vel = motors[motor_idx].vel;
-  torque =motors[motor_idx].tor;
+{
+  if (motor_idx < 0 || static_cast<std::size_t>(motor_idx) >= motors.size())
+  {
+    ROS_WARN_THROTTLE(1.0, "get_motor_data motor index %d out of range", motor_idx);
+    pos = 0.0;
+    vel = 0.0;
+    torque = 0.0;
+    return;
+  }
+  const auto& motor = motors[static_cast<std::size_t>(motor_idx)];
+  pos = motor.pos;
+  vel = motor.vel;
+  torque = motor.tor;
 }
 
-/**************************************
-功能: 串口通讯校验函数，数据包n有个字节，第n-1个字节为校验位，第n个字节位帧尾。第1个字节到第n-2个字节数据按位异或的结果与第n-1个字节对比，即为BCC校验
-输入参数： Count_Number：数据包前几个字节加入校验   mode：对发送数据还是接收数据进行校验
-***************************************/
 unsigned char robot::Check_Sum(unsigned char Count_Number,unsigned char mode)
 {
-    unsigned char check_sum=0,k;
+  const CheckMode check_mode = (mode == READ_DATA_CHECK) ? CheckMode::Receive : CheckMode::Send;
+  return computeChecksum(static_cast<std::size_t>(Count_Number), check_mode);
+}
 
-    if(mode==0) //Receive data mode //接收数据模式
+uint8_t robot::computeChecksum(std::size_t count_number, CheckMode mode) const
+{
+  uint8_t check_sum = 0;
+  if (mode == CheckMode::Receive)
+  {
+    const std::size_t max_count = std::min(count_number, receive_buffer_.size());
+    for (std::size_t k = 0; k < max_count; ++k)
     {
-        for(k=0;k<Count_Number;k++)
-        {
-            check_sum=check_sum^Receive_Data.rx[k]; //By bit or by bit //按位异或
-        }
+      check_sum = static_cast<uint8_t>(check_sum ^ receive_buffer_[k]);
     }
-
-    if(mode==1) //Send data mode //发送数据模式
+  }
+  else
+  {
+    const std::size_t max_count = std::min(count_number, Send_Data.tx.size());
+    for (std::size_t k = 0; k < max_count; ++k)
     {
-        for(k=0;k<Count_Number;k++)
-        {
-            check_sum=check_sum^Send_Data.tx[k]; //By bit or by bit //按位异或
-        }
+      check_sum = static_cast<uint8_t>(check_sum ^ Send_Data.tx[k]);
     }
-  return check_sum; //Returns the bitwise XOR result //返回按位异或结果
+  }
+  return check_sum;
 }
 
 void robot::dm4310_fbdata(motor_data_t& moto,uint8_t *data)
@@ -341,8 +530,8 @@ void robot::dm6006_fbdata(motor_data_t& moto,uint8_t *data)
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
   moto.pos = uint_to_float(moto.p_int, P_MIN3, P_MAX3, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN3, V_MAX3, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN3, T_MAX3, 12);  // (-10.0,10.0)
+  moto.vel = uint_to_float(moto.v_int, V_MIN3, V_MAX3, 12); // (-45.0,45.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN3, T_MAX3, 12);  // (-12.0,12.0)
 }
 
 void robot::dm8006_fbdata(motor_data_t& moto,uint8_t *data)
@@ -351,8 +540,8 @@ void robot::dm8006_fbdata(motor_data_t& moto,uint8_t *data)
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
   moto.pos = uint_to_float(moto.p_int, P_MIN4, P_MAX4, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN4, V_MAX4, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN4, T_MAX4, 12);  // (-10.0,10.0)
+  moto.vel = uint_to_float(moto.v_int, V_MIN4, V_MAX4, 12); // (-45.0,45.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN4, T_MAX4, 12);  // (-20.0,20.0)
 }
 
 void robot::dm6248p_fbdata(motor_data_t& moto,uint8_t *data)
@@ -360,9 +549,9 @@ void robot::dm6248p_fbdata(motor_data_t& moto,uint8_t *data)
   moto.p_int=(data[0]<<8)|data[1];
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
-  moto.pos = uint_to_float(moto.p_int, P_MIN5, P_MAX5, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN5, V_MAX5, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN5, T_MAX5, 12);  // (-10.0,10.0)
+  moto.pos = uint_to_float(moto.p_int, P_MIN5, P_MAX5, 16); // (-12.566,12.566)
+  moto.vel = uint_to_float(moto.v_int, V_MIN5, V_MAX5, 12); // (-20.0,20.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN5, T_MAX5, 12);  // (-120.0,120.0)
 }
 
 void robot::dm10010l_fbdata(motor_data_t& moto,uint8_t *data)
@@ -371,27 +560,21 @@ void robot::dm10010l_fbdata(motor_data_t& moto,uint8_t *data)
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
   moto.pos = uint_to_float(moto.p_int, P_MIN6, P_MAX6, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN6, V_MAX6, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN6, T_MAX6, 12);  // (-10.0,10.0)
+  moto.vel = uint_to_float(moto.v_int, V_MIN6, V_MAX6, 12); // (-25.0,25.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN6, T_MAX6, 12);  // (-200.0,200.0)
 }
 
 int16_t robot::float_to_uint(float x_float, float x_min, float x_max, int bits)
 {
-  /* Converts a float to an unsigned int, given range and number of bits */
   float span = x_max - x_min;
   float offset = x_min;
-  return (int16_t)((x_float-offset)*((float)((1<<bits)-1))/span);
+  return static_cast<int16_t>((x_float - offset) * ((static_cast<float>((1 << bits) - 1)) / span));
 }
 
 float robot::uint_to_float(int x_int, float x_min, float x_max, int bits)
 {
-  /* converts unsigned int to float, given range and number of bits */
   float span = x_max - x_min;
-  float offset = x_min;
-  return ((float)x_int)*span/((float)((1<<bits)-1)) + offset;
+  return static_cast<float>(x_int) * span / static_cast<float>((1 << bits) - 1) + x_min;
 }
 
-
-}
-
-
+}  // namespace dmbot_serial

--- a/src/dmbot_serial_leftarm/src/stm32_motor_bridge.py
+++ b/src/dmbot_serial_leftarm/src/stm32_motor_bridge.py
@@ -11,9 +11,6 @@ from std_msgs.msg import Float64MultiArray, Float32
 FRAME_HEADER = 0x7B
 PACKET_LENGTH = 11  # 1B头 + 1B id + 8B payload + 1B XOR
 
-# ========= 新增：参数化 =========
-NUM_MOTORS = rospy.get_param("/stm32_motor_bridge/num_motors", 14)
-# ==============================
 
 def xor_checksum(data_bytes):
     c = 0
@@ -21,8 +18,9 @@ def xor_checksum(data_bytes):
         c ^= b
     return c & 0xFF
 
-def build_packet(motor_id, payload_8bytes):
-    assert 0 <= motor_id < NUM_MOTORS, "motor_id 越界"
+
+def build_packet(motor_id, payload_8bytes, num_motors):
+    assert 0 <= motor_id < num_motors, "motor_id 越界"
     if len(payload_8bytes) != 8:
         raise ValueError("payload 必须 8 字节")
     buf = bytearray(10)
@@ -32,51 +30,57 @@ def build_packet(motor_id, payload_8bytes):
     chksum = xor_checksum(buf)
     return bytes(buf) + bytes([chksum])
 
-def clamp_int16(v): return max(-32768, min(32767, int(round(v))))
+
+def clamp_int16(v):
+    return max(-32768, min(32767, int(round(v))))
+
 
 def encode_pd_q15(pos, vel, kp, kd, scale=1000, big_endian=True):
     # 注意：如果下位机忽略 vel，你也可以置 0
     p = clamp_int16(pos * scale)
     v = clamp_int16(vel * scale)
-    kpp = clamp_int16(kp  * scale)
-    kdd = clamp_int16(kd  * scale)
+    kpp = clamp_int16(kp * scale)
+    kdd = clamp_int16(kd * scale)
     vals = [p, v, kpp, kdd]
     b = bytearray(8)
     for i, val in enumerate(vals):
         if big_endian:
-            b[2*i]   = (val >> 8) & 0xFF
-            b[2*i+1] =  val       & 0xFF
+            b[2 * i] = (val >> 8) & 0xFF
+            b[2 * i + 1] = val & 0xFF
         else:
-            b[2*i]   =  val       & 0xFF
-            b[2*i+1] = (val >> 8) & 0xFF
+            b[2 * i] = val & 0xFF
+            b[2 * i + 1] = (val >> 8) & 0xFF
     return b
+
 
 class Stm32Bridge(object):
     def __init__(self):
-        self.port   = rospy.get_param("~port", "/dev/mcu_leftarm")
-        self.baud   = int(rospy.get_param("~baud", 921600))       # 改成 921600
-        self.rate_hz= float(rospy.get_param("~rate", 100.0))
-        self.mode   = rospy.get_param("~mode", "pd_q15")
-        self.scale  = float(rospy.get_param("~scale", 1000.0))
+        self.robot_name = rospy.get_param("~robot_name", rospy.get_param("robot_name", "ludan"))
+        self.num_motors = self._resolve_motor_count()
+        rospy.loginfo("stm32_motor_bridge: %s using %d motors", self.robot_name, self.num_motors)
+
+        self.port = rospy.get_param("~port", "/dev/mcu_leftarm")
+        self.baud = int(rospy.get_param("~baud", 921600))
+        self.rate_hz = float(rospy.get_param("~rate", 100.0))
+        self.mode = rospy.get_param("~mode", "pd_q15")
+        self.scale = float(rospy.get_param("~scale", 1000.0))
         self.big_endian = bool(rospy.get_param("~big_endian", True))
 
-        # /hybrid_cmd 长度 = 5*NUM_MOTORS
-        self.cmd = [0.0] * (5 * NUM_MOTORS)
+        self.cmd = [0.0] * (5 * self.num_motors)
         self.cmd_lock = threading.Lock()
         self.last_cmd_time = 0.0
         self.timeout = float(rospy.get_param("~timeout", 0.2))
 
         self.emergency_stop = False
 
-        # 方向映射长度改成 NUM_MOTORS（按你实际填充）
-        default_dir = [1]*NUM_MOTORS
-        # 例：原来 10 路是 [ 1,1,-1,1,1, -1,1,-1,-1,-1 ]
-        # 你可以在参数服务器覆盖，也可以这里直接写 14 路的表
-        self.direction = rospy.get_param("~direction", default_dir)
+        default_dir = [1] * self.num_motors
+        direction_param = rospy.get_param("~direction", default_dir)
+        if len(direction_param) < self.num_motors:
+            direction_param = list(direction_param) + [1] * (self.num_motors - len(direction_param))
+        self.direction = list(direction_param[:self.num_motors])
 
-        # raw8 的默认 payload
         self.raw_payload_default = [0x7F, 0xFF, 0x84, 0x30, 0x00, 0x33, 0x37, 0xFF]
-        self.raw_payloads = [bytearray(self.raw_payload_default) for _ in range(NUM_MOTORS)]
+        self.raw_payloads = [bytearray(self.raw_payload_default) for _ in range(self.num_motors)]
 
         self.ser = serial.Serial(self.port, self.baud, timeout=0.05)
         rospy.loginfo("stm32_motor_bridge 串口已打开 %s @ %d", self.port, self.baud)
@@ -84,8 +88,7 @@ class Stm32Bridge(object):
         rospy.Subscriber("/hybrid_cmd", Float64MultiArray, self.hybrid_cb, queue_size=1)
         rospy.Subscriber("/emergency_stop", Float32, self.emg_cb, queue_size=1)
 
-        # raw8 订阅也扩到 NUM_MOTORS
-        for mid in range(NUM_MOTORS):
+        for mid in range(self.num_motors):
             rospy.Subscriber(f"/stm32/raw8/motor{mid}", Float64MultiArray,
                              lambda msg, i=mid: self.raw8_cb(i, msg), queue_size=1)
 
@@ -93,9 +96,34 @@ class Stm32Bridge(object):
         self.th = threading.Thread(target=self.loop, daemon=True)
         self.th.start()
 
+    @staticmethod
+    def _count_from_layout(layout):
+        return len(layout) if isinstance(layout, list) and len(layout) > 0 else 0
+
+    def _resolve_motor_count(self):
+        layout = rospy.get_param("~motor_layout", None)
+        count = self._count_from_layout(layout)
+        if count:
+            return count
+
+        if self.robot_name:
+            global_layout = rospy.get_param(f"/{self.robot_name}/motor_layout", None)
+            count = self._count_from_layout(global_layout)
+            if count:
+                rospy.set_param("~motor_layout", global_layout)
+                return count
+
+        fallback_layout = rospy.get_param("/motor_layout", None)
+        count = self._count_from_layout(fallback_layout)
+        if count:
+            rospy.set_param("~motor_layout", fallback_layout)
+            return count
+
+        return int(rospy.get_param("~num_motors", rospy.get_param("/stm32_motor_bridge/num_motors", 14)))
+
     def hybrid_cb(self, msg: Float64MultiArray):
         data = list(msg.data)
-        need = 5 * NUM_MOTORS
+        need = 5 * self.num_motors
         if len(data) != need:
             rospy.logwarn_throttle(1.0, "/hybrid_cmd 长度=%d（需 %d），忽略", len(data), need)
             return
@@ -108,6 +136,9 @@ class Stm32Bridge(object):
         rospy.logwarn("收到急停: %s", self.emergency_stop)
 
     def raw8_cb(self, motor_id, msg: Float64MultiArray):
+        if not (0 <= motor_id < self.num_motors):
+            rospy.logwarn_throttle(1.0, "raw8 motor id %d 越界", motor_id)
+            return
         arr = msg.data
         if len(arr) != 8:
             rospy.logwarn("raw8 电机 %d 长度=%d(需8)，忽略", motor_id, len(arr))
@@ -128,14 +159,12 @@ class Stm32Bridge(object):
             with self.cmd_lock:
                 d = self.cmd[:]
 
-            # 切片都按 NUM_MOTORS
-            pos = d[0:NUM_MOTORS]
-            vel = d[NUM_MOTORS:2*NUM_MOTORS]
-            kp  = d[2*NUM_MOTORS:3*NUM_MOTORS]
-            kd  = d[3*NUM_MOTORS:4*NUM_MOTORS]
-            # tau = d[4*NUM_MOTORS:5*NUM_MOTORS]  # 如固件不用可忽略
+            pos = d[0:self.num_motors]
+            vel = d[self.num_motors:2 * self.num_motors]
+            kp = d[2 * self.num_motors:3 * self.num_motors]
+            kd = d[3 * self.num_motors:4 * self.num_motors]
 
-            for mid in range(NUM_MOTORS):
+            for mid in range(self.num_motors):
                 if self.mode == "raw8":
                     payload = self.raw_payloads[mid]
                 else:
@@ -145,7 +174,7 @@ class Stm32Bridge(object):
                     kdd = kd[mid]
                     payload = encode_pd_q15(p, v, kpp, kdd, scale=self.scale, big_endian=self.big_endian)
 
-                pkt = build_packet(mid, payload)
+                pkt = build_packet(mid, payload, self.num_motors)
                 try:
                     self.ser.write(pkt)
                 except Exception as e:
@@ -158,11 +187,12 @@ class Stm32Bridge(object):
         self.run = False
         try:
             self.th.join(timeout=1.0)
-        except:
+        except Exception:
             pass
         if self.ser and self.ser.is_open:
             self.ser.close()
         rospy.loginfo("stm32_motor_bridge 已关闭")
+
 
 if __name__ == "__main__":
     rospy.init_node("stm32_motor_bridge")

--- a/src/dmbot_serial_leftarm/src/test_motor.cpp
+++ b/src/dmbot_serial_leftarm/src/test_motor.cpp
@@ -4,8 +4,6 @@
 #include <vector>
 #include <iostream>
 
-static constexpr int N = NUM_MOTORS;  // 14
-
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "test_motor");
@@ -25,27 +23,33 @@ int main(int argc, char **argv)
 
   // 创建上位机串口接口
   dmbot_serial::robot rb;
+  const std::size_t motor_count = rb.motorCount();
+  if (motor_count == 0)
+  {
+    ROS_ERROR("未配置任何电机，退出 test_motor");
+    return 1;
+  }
 
-  std::vector<double> pos_cmd(N, 0.0), vel_cmd(N, 0.0), tor_cmd(N, 0.0);
+  std::vector<double> pos_cmd(motor_count, 0.0), vel_cmd(motor_count, 0.0), tor_cmd(motor_count, 0.0);
 
   const double two_pi = 2.0 * M_PI;
   const double dt = 1.0 / 200.0;
   double t = 0.0;
 
-  ROS_INFO("test_motor running with N=%d, pos_amp=%.3f rad, freq=%.3f Hz, kp=%.3f, kd=%.3f",
-           N, pos_amp, freq, kp, kd);
+  ROS_INFO("test_motor running with N=%zu, pos_amp=%.3f rad, freq=%.3f Hz, kp=%.3f, kd=%.3f",
+           motor_count, pos_amp, freq, kp, kd);
   ROS_INFO("默认不动，若要小幅测试请传参：_pos_amp:=0.05 _kp:=2.0 _kd:=0.1");
 
   while (ros::ok())
   {
-    // 生成 14 路命令（简单正弦，带相位错开，便于识别）
-    for (int i = 0; i < N; ++i)
+    // 生成多路命令（简单正弦，带相位错开，便于识别）
+    for (std::size_t i = 0; i < motor_count; ++i)
     {
-      double phase = (two_pi * i) / N;
+      double phase = (two_pi * static_cast<double>(i)) / static_cast<double>(motor_count);
       pos_cmd[i] = pos_amp * std::sin(two_pi * freq * t + phase);
       vel_cmd[i] = 0.0;   // 如固件需要也可给导数
       tor_cmd[i] = 0.0;
-      rb.fresh_cmd_motor_data(pos_cmd[i], vel_cmd[i], tor_cmd[i], kp, kd, i);
+      rb.fresh_cmd_motor_data(pos_cmd[i], vel_cmd[i], tor_cmd[i], kp, kd, static_cast<int>(i));
     }
 
     // 下发给 STM32
@@ -53,10 +57,18 @@ int main(int argc, char **argv)
 
     // 可选：打印少量反馈
     if (static_cast<int>(t*10) % 10 == 0) { // 约每 0.1s 打印一次
-      double p0,v0,t0, p7,v7,t7, p13,v13,t13;
+      double p0 = 0.0, v0 = 0.0, t0 = 0.0;
+      double p7 = 0.0, v7 = 0.0, t7 = 0.0;
+      double p13 = 0.0, v13 = 0.0, t13 = 0.0;
       rb.get_motor_data(p0,v0,t0,0);
-      rb.get_motor_data(p7,v7,t7,7);
-      rb.get_motor_data(p13,v13,t13,13);
+      if (motor_count > 7)
+      {
+        rb.get_motor_data(p7,v7,t7,7);
+      }
+      if (motor_count > 13)
+      {
+        rb.get_motor_data(p13,v13,t13,13);
+      }
       ROS_INFO_THROTTLE(0.5, "m0 pos=%.3f, m7 pos=%.3f, m13 pos=%.3f", p0, p7, p13);
     }
 

--- a/src/dmbot_serial_neck/src/robot_connect.cpp
+++ b/src/dmbot_serial_neck/src/robot_connect.cpp
@@ -1,188 +1,354 @@
 #include <dmbot_serial/robot_connect.h>
 
+#include <algorithm>
+#include <cctype>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <ros/console.h>
+#include <xmlrpcpp/XmlRpcValue.h>
 
 namespace dmbot_serial
 {
+namespace
+{
+const std::vector<std::string> kCanonicalLimbs = {"left_arm", "right_arm", "left_leg", "right_leg", "waist", "neck"};
+
+std::string normalizeToken(const std::string& raw)
+{
+  std::string result;
+  result.reserve(raw.size());
+  char last = '\0';
+  for (char c : raw)
+  {
+    const unsigned char uc = static_cast<unsigned char>(c);
+    if (std::isalnum(uc) != 0)
+    {
+      result.push_back(static_cast<char>(std::tolower(uc)));
+      last = result.back();
+    }
+    else if (last != '_')
+    {
+      result.push_back('_');
+      last = '_';
+    }
+  }
+  while (!result.empty() && result.back() == '_')
+  {
+    result.pop_back();
+  }
+  if (result.empty())
+  {
+    return "joint";
+  }
+  return result;
+}
+
+std::string buildMotorName(const std::string& robot, const std::string& limb, const std::string& joint,
+                           std::map<std::string, int>& usage)
+{
+  std::string base = robot + "_" + limb + "_" + joint;
+  std::string candidate = base;
+  int index = 1;
+  while (usage.count(candidate) != 0)
+  {
+    candidate = base + "_" + std::to_string(++index);
+  }
+  usage[candidate] = 1;
+  return candidate;
+}
+
+std::vector<MotorLayoutEntry> parseLayout(const XmlRpc::XmlRpcValue& param)
+{
+  std::vector<MotorLayoutEntry> layout;
+  if (param.getType() != XmlRpc::XmlRpcValue::TypeArray)
+  {
+    return layout;
+  }
+  layout.reserve(param.size());
+  for (int i = 0; i < param.size(); ++i)
+  {
+    if (param[i].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      continue;
+    }
+    MotorLayoutEntry entry;
+    if (param[i].hasMember("limb") && param[i]["limb"].getType() == XmlRpc::XmlRpcValue::TypeString)
+    {
+      entry.limb = static_cast<std::string>(param[i]["limb"]);
+    }
+    if (param[i].hasMember("joint") && param[i]["joint"].getType() == XmlRpc::XmlRpcValue::TypeString)
+    {
+      entry.joint = static_cast<std::string>(param[i]["joint"]);
+    }
+    if (param[i].hasMember("type") && param[i]["type"].getType() == XmlRpc::XmlRpcValue::TypeString)
+    {
+      entry.type = static_cast<std::string>(param[i]["type"]);
+    }
+    if (!entry.limb.empty())
+    {
+      layout.push_back(entry);
+    }
+  }
+  return layout;
+}
+}  // namespace
+
 robot::robot()
 {
+  ros::NodeHandle nh_private("~");
+  nh_private.param<std::string>("robot_name", robot_name, std::string("ludan"));
+  n.param("robot_name", robot_name, robot_name);
+  nh_private.param<std::string>("port", motor_serial_port, std::string("/dev/ttyACM1"));
+  nh_private.param("baud", motor_seial_baud, 921600);
 
-  n.param("port", motor_serial_port, std::string("/dev/ttyACM1")); 
-  n.param("baud", motor_seial_baud, 921600);
-  
-  int i=0;
-  for(auto& motor:motors)
-  {
-      motor.name = "Motor_" + std::to_string(i);   
-      motor.pos = 0.0f;
-      motor.vel = 0.0f;
-      motor.tor = 0.0f;
-      motor.tor_set = 0.0f;
-      motor.pos_set = 0.0f;
-      motor.vel_set = 0.0f;
-      motor.kp = 0.0f;
-      motor.kd = 0.0f;
-      motor.index=i;
-      i++;
-  }
-  motors[0].type = "10010l";
-  motors[1].type = "10010l";
-  motors[2].type = "10010l";
-  motors[3].type = "6248p";                
-  motors[4].type = "4340";
-  motors[5].type = "4340";   
-  motors[6].type = "4340";
-  
-  // motors[7].type = "10010l";
-  // motors[8].type = "10010l";
-  // motors[9].type = "10010l";                
-  // motors[10].type = "6248p";
-  // motors[11].type = "4340";
-  // motors[12].type = "4340";                
-  // motors[13].type = "4340";
+  initializeMotorConfiguration(loadMotorLayout());
+  ensureReceiveBuffer();
 
-    
-  motors[7].type = "6248p";
-  motors[8].type = "6248p";
-  motors[9].type = "6248p";                
-  motors[10].type = "4340";
-  motors[11].type = "4340";
-  motors[12].type = "4340";                
-  motors[13].type = "4340";
-   
-  init_motor_serial();//初始化串口
+  init_motor_serial();
 
   rec_thread = std::thread(&robot::get_motor_data_thread, this);
-  
-  joint_state_pub = n.advertise<sensor_msgs::JointState>("joint_states", 10);   
- // pub_thread = std::thread(&robot::publishJointStates, this);
+
+  joint_state_pub = n.advertise<sensor_msgs::JointState>("joint_states", 10);
 
   ros::Duration(2.0).sleep();
 
-  ROS_INFO("robot init complete");
-
+  ROS_INFO_STREAM(robot_name << " robot init complete. configured motors: " << motors.size());
 }
+
 robot::~robot()
-{   
-   for(int i=0;i<NUM_MOTORS;i++)
+{
+  for (std::size_t i = 0; i < motors.size(); ++i)
   {
-    fresh_cmd_motor_data(0.0, 0.0, 0.0, 0.0, 0.0, i); //更新发给电机的参数、力矩等
+    fresh_cmd_motor_data(0.0, 0.0, 0.0, 0.0, 0.0, static_cast<int>(i));
   }
-  
+
   send_motor_data();
 
   stop_thread_ = true;
 
-  if(rec_thread.joinable())
+  if (rec_thread.joinable())
   {
-    rec_thread.join(); 
+    rec_thread.join();
   }
   if (serial_motor.isOpen())
   {
-    serial_motor.close(); 
+    serial_motor.close();
   }
-  
- // if(pub_thread.joinable())
-  //{
- //     pub_thread.join(); 
-  //}
-
 }
 
 void robot::init_motor_serial()
-{         
-    try
-    {
-      serial_motor.setPort(motor_serial_port);
-      serial_motor.setBaudrate(motor_seial_baud);
-      serial_motor.setFlowcontrol(serial::flowcontrol_none);
-      serial_motor.setParity(serial::parity_none); //default is parity_none
-      serial_motor.setStopbits(serial::stopbits_one);
-      serial_motor.setBytesize(serial::eightbits);
-      serial::Timeout time_out = serial::Timeout::simpleTimeout(20);
-      serial_motor.setTimeout(time_out);
-      serial_motor.open();
-    } 
-    catch (serial::IOException &e)  // 抓取异常
-    {
-        ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
-        exit(0);
-    }
-    if (serial_motor.isOpen())
-    {
-        ROS_INFO_STREAM("In single initialization,Motor Serial Port initialized");
-    }
-    else
-    {
-        ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
-        exit(0);
-    }
-   
+{
+  try
+  {
+    serial_motor.setPort(motor_serial_port);
+    serial_motor.setBaudrate(motor_seial_baud);
+    serial_motor.setFlowcontrol(serial::flowcontrol_none);
+    serial_motor.setParity(serial::parity_none);
+    serial_motor.setStopbits(serial::stopbits_one);
+    serial_motor.setBytesize(serial::eightbits);
+    serial::Timeout time_out = serial::Timeout::simpleTimeout(20);
+    serial_motor.setTimeout(time_out);
+    serial_motor.open();
+  }
+  catch (serial::IOException& /*e*/)
+  {
+    ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
+    throw;
+  }
+  if (serial_motor.isOpen())
+  {
+    ROS_INFO_STREAM("In single initialization,Motor Serial Port initialized");
+  }
+  else
+  {
+    ROS_ERROR_STREAM("In single initialization,Unable to open motor serial port ");
+    throw std::runtime_error("Unable to open motor serial port");
+  }
+}
+
+void robot::ensureReceiveBuffer()
+{
+  const std::size_t expected = motors.empty() ? 0 : (1 + motors.size() * kFeedbackWordSize + 1);
+  receive_buffer_.assign(expected, 0);
+}
+
+void robot::initializeMotorConfiguration(const std::vector<MotorLayoutEntry>& layout)
+{
+  motors.clear();
+  limb_index_map_.clear();
+  for (const auto& limb : kCanonicalLimbs)
+  {
+    limb_index_map_[normalizeToken(limb)] = {};
+  }
+
+  motors.reserve(layout.size());
+  std::map<std::string, int> name_usage;
+
+  for (std::size_t idx = 0; idx < layout.size(); ++idx)
+  {
+    motor_data_t motor{};
+    motor.index = static_cast<int>(idx);
+    motor.limb = normalizeToken(layout[idx].limb);
+    const std::string joint_token = layout[idx].joint.empty() ? ("joint_" + std::to_string(idx + 1)) : layout[idx].joint;
+    motor.joint = normalizeToken(joint_token);
+    motor.type = layout[idx].type.empty() ? "4340" : layout[idx].type;
+    motor.name = buildMotorName(robot_name, motor.limb, motor.joint, name_usage);
+
+    motor.pos = 0.0f;
+    motor.vel = 0.0f;
+    motor.tor = 0.0f;
+    motor.tor_set = 0.0f;
+    motor.pos_set = 0.0f;
+    motor.vel_set = 0.0f;
+    motor.kp = 0.0f;
+    motor.kd = 0.0f;
+
+    limb_index_map_[motor.limb].push_back(idx);
+    motors.push_back(motor);
+  }
+
+  ensureReceiveBuffer();
+}
+
+std::vector<MotorLayoutEntry> robot::defaultMotorLayout() const
+{
+  return {
+      {"right_arm", "shoulder_yaw", "10010l"},
+      {"right_arm", "shoulder_pitch", "10010l"},
+      {"right_arm", "shoulder_roll", "10010l"},
+      {"right_arm", "elbow_pitch", "6248p"},
+      {"right_arm", "wrist_pitch", "4340"},
+      {"right_arm", "wrist_roll", "4340"},
+      {"right_arm", "wrist_yaw", "4340"},
+      {"left_arm", "shoulder_yaw", "6248p"},
+      {"left_arm", "shoulder_pitch", "6248p"},
+      {"left_arm", "shoulder_roll", "6248p"},
+      {"left_arm", "elbow_pitch", "4340"},
+      {"left_arm", "wrist_pitch", "4340"},
+      {"left_arm", "wrist_roll", "4340"},
+      {"left_arm", "wrist_yaw", "4340"}};
+}
+
+std::vector<MotorLayoutEntry> robot::loadMotorLayout()
+{
+  ros::NodeHandle nh_private("~");
+  XmlRpc::XmlRpcValue param;
+  std::vector<MotorLayoutEntry> layout;
+
+  if (nh_private.getParam("motor_layout", param))
+  {
+    layout = parseLayout(param);
+  }
+  else if (n.getParam(robot_name + "/motor_layout", param))
+  {
+    layout = parseLayout(param);
+  }
+  else if (n.getParam("motor_layout", param))
+  {
+    layout = parseLayout(param);
+  }
+
+  if (layout.empty())
+  {
+    ROS_WARN_STREAM("motor_layout parameter not found or empty. Using default layout for " << robot_name);
+    layout = defaultMotorLayout();
+  }
+  return layout;
+}
+
+std::size_t robot::motorCount() const
+{
+  return motors.size();
 }
 
 void robot::get_motor_data_thread()
-{   
-//ros::Rate ra(100000); 
-  while (ros::ok()&&!stop_thread_)
-  {    
-    if (!serial_motor.isOpen())
+{
+  std::size_t count = 0;
+  while (ros::ok() && !stop_thread_)
+  {
+    if (motors.empty() || receive_buffer_.empty())
     {
-      ROS_WARN("In get_motor_data_thread,motor serial port unopen");
-    }       
-
-  short transition_16=0;  //中间变量
-  uint8_t i=0,check=0, error=1,Receive_Data_Pr[1];  //临时变量，保存下位机数据
-  static int count; //静态变量，用于计数
-  serial_motor.read(Receive_Data_Pr,sizeof(Receive_Data_Pr)); //通过串口读取下位机发送过来的数据
-  
-
-  Receive_Data.rx[count] = Receive_Data_Pr[0];  //串口数据填入数组
-  Receive_Data.Frame_Header = Receive_Data.rx[0]; 
-
-  if(Receive_Data_Pr[0] == FRAME_HEADER || count>0) //确保数组第一个数据为FRAME_HEADER
-      count++;
-  else 
-    count=0;
-  if (count == RECEIVE_DATA_SIZE) {  // 72 when NUM_MOTORS=14
-  count = 0;
-  check = Check_Sum(RECEIVE_DATA_SIZE - 1, READ_DATA_CHECK);
-  if (check == Receive_Data.rx[RECEIVE_DATA_SIZE - 1]) {
-    error = 0;
-  }
-  if (error == 0) {
-    for (int i = 0; i < NUM_MOTORS; ++i) {
-      uint8_t* p = &Receive_Data.rx[1 + i*5];
-      auto& m = motors[i];
-      if      (m.type == "4340")   dm4340_fbdata(m, p);
-      else if (m.type == "4310")   dm4310_fbdata(m, p);
-      else if (m.type == "6006")   dm6006_fbdata(m, p);
-      else if (m.type == "8006")   dm8006_fbdata(m, p);
-      else if (m.type == "6248p")  dm6248p_fbdata(m, p);
-      else if (m.type == "10010l") dm10010l_fbdata(m, p);
-      else                         dm4340_fbdata(m, p); // 默认兜底
+      ros::Duration(0.05).sleep();
+      continue;
     }
 
-  }
-}
-   
-  }
-}
+    if (!serial_motor.isOpen())
+    {
+      ROS_WARN_THROTTLE(1.0, "In get_motor_data_thread, motor serial port unopen");
+      ros::Duration(0.05).sleep();
+      continue;
+    }
 
+    uint8_t byte = 0;
+    try
+    {
+      serial_motor.read(&byte, 1);
+    }
+    catch (serial::IOException& e)
+    {
+      ROS_ERROR_THROTTLE(1.0, "Failed to read from motor serial port: %s", e.what());
+      continue;
+    }
+
+    if (count == 0)
+    {
+      if (byte != FRAME_HEADER)
+      {
+        continue;
+      }
+    }
+
+    receive_buffer_[count++] = byte;
+
+    if (count == receive_buffer_.size())
+    {
+      count = 0;
+      const uint8_t checksum = computeChecksum(receive_buffer_.size() - 1, CheckMode::Receive);
+      if (checksum != receive_buffer_.back())
+      {
+        ROS_WARN_THROTTLE(1.0, "Checksum mismatch while parsing motor feedback");
+        continue;
+      }
+
+      for (std::size_t i = 0; i < motors.size(); ++i)
+      {
+        auto& motor = motors[i];
+        uint8_t* p = receive_buffer_.data() + 1 + i * kFeedbackWordSize;
+        if      (motor.type == "4340")   dm4340_fbdata(motor, p);
+        else if (motor.type == "4310")   dm4310_fbdata(motor, p);
+        else if (motor.type == "6006")   dm6006_fbdata(motor, p);
+        else if (motor.type == "8006")   dm8006_fbdata(motor, p);
+        else if (motor.type == "6248p")  dm6248p_fbdata(motor, p);
+        else if (motor.type == "10010l") dm10010l_fbdata(motor, p);
+        else                               dm4340_fbdata(motor, p);
+      }
+    }
+  }
+}
 
 void robot::publishJointStates()
 {
-  ros::Rate rate(1000); 
+  ros::Rate rate(1000);
   while (ros::ok())
   {
-      sensor_msgs::JointState joint_state_msg;
+    sensor_msgs::JointState joint_state_msg;
 
-      for(int i=0; i<NUM_MOTORS; i++)
-      {    
-          joint_state_msg.name.push_back(motors[i].name);                   
-         
-          joint_state_msg.position.push_back(motors[i].pos);
-          joint_state_msg.velocity.push_back(motors[i].vel);
-          joint_state_msg.effort.push_back(motors[i].tor); 
-      }
+    joint_state_msg.name.reserve(motors.size());
+    joint_state_msg.position.reserve(motors.size());
+    joint_state_msg.velocity.reserve(motors.size());
+    joint_state_msg.effort.reserve(motors.size());
+
+    for (const auto& motor : motors)
+    {
+      joint_state_msg.name.push_back(motor.name);
+      joint_state_msg.position.push_back(motor.pos);
+      joint_state_msg.velocity.push_back(motor.vel);
+      joint_state_msg.effort.push_back(motor.tor);
+    }
 
     joint_state_pub.publish(joint_state_msg);
 
@@ -191,128 +357,151 @@ void robot::publishJointStates()
 }
 
 void robot::send_motor_data()
-{   
-  ros::Time last_time2 = ros::Time::now();
-  for(auto& motor:motors)
-  {  
-    uint16_t pos_tmp, vel_tmp, kp_tmp, kd_tmp, tor_tmp;
-    if(motor.type == "8006")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN4,  P_MAX4,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN4,  V_MAX4,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN4, KP_MAX4, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN4, KD_MAX4, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN4,  T_MAX4,  12);
-    }
-    else if(motor.type == "6006")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN3,  P_MAX3,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN3,  V_MAX3,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN3, KP_MAX3, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN3, KD_MAX3, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN3,  T_MAX3,  12);
-    }
-    else  if(motor.type == "4340")
+{
+  if (motors.empty())
+  {
+    return;
+  }
+
+  for (auto& motor : motors)
+  {
+    uint16_t pos_tmp = 0;
+    uint16_t vel_tmp = 0;
+    uint16_t kp_tmp = 0;
+    uint16_t kd_tmp = 0;
+    uint16_t tor_tmp = 0;
+
+    if (motor.type == "8006")
     {
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN2,  P_MAX2,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN2,  V_MAX2,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN2, KP_MAX2, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN2, KD_MAX2, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN2,  T_MAX2,  12);
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN4,  P_MAX4,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN4,  V_MAX4,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN4, KP_MAX4, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN4, KD_MAX4, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN4,  T_MAX4,  12);
     }
-    else  if(motor.type == "4310")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN1,  P_MAX1,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN1,  V_MAX1,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN1, KP_MAX1, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN1, KD_MAX1, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN1,  T_MAX1,  12);
+    else if (motor.type == "6248p")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN5,  P_MAX5,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN5,  V_MAX5,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN5, KP_MAX5, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN5, KD_MAX5, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN5,  T_MAX5,  12);
     }
-    else  if(motor.type == "6248p")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN5,  P_MAX5,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN5,  V_MAX5,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN5, KP_MAX5, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN5, KD_MAX5, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN5,  T_MAX5,  12);
+    else if (motor.type == "6006")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN3,  P_MAX3,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN3,  V_MAX3,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN3, KP_MAX3, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN3, KD_MAX3, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN3,  T_MAX3,  12);
     }
-    else  if(motor.type == "10010l")
-    {   
-        pos_tmp = float_to_uint(motor.pos_set,  P_MIN6,  P_MAX6,  16);
-        vel_tmp = float_to_uint(motor.vel_set,  V_MIN6,  V_MAX6,  12);
-        kp_tmp  = float_to_uint(motor.kp,   KP_MIN6, KP_MAX6, 12);
-        kd_tmp  = float_to_uint(motor.kd,   KD_MIN6, KD_MAX6, 12);
-        tor_tmp = float_to_uint(motor.tor_set, T_MIN6,  T_MAX6,  12);
+    else if (motor.type == "4310")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN1,  P_MAX1,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN1,  V_MAX1,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN1, KP_MAX1, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN1, KD_MAX1, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN1,  T_MAX1,  12);
     }
-    Send_Data.tx[0]=FRAME_HEADER; 
-    Send_Data.tx[1]=motor.index;
+    else if (motor.type == "10010l")
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN6,  P_MAX6,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN6,  V_MAX6,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN6, KP_MAX6, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN6, KD_MAX6, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN6,  T_MAX6,  12);
+    }
+    else
+    {
+      pos_tmp = float_to_uint(motor.pos_set,  P_MIN2,  P_MAX2,  16);
+      vel_tmp = float_to_uint(motor.vel_set,  V_MIN2,  V_MAX2,  12);
+      kp_tmp  = float_to_uint(motor.kp,       KP_MIN2, KP_MAX2, 12);
+      kd_tmp  = float_to_uint(motor.kd,       KD_MIN2, KD_MAX2, 12);
+      tor_tmp = float_to_uint(motor.tor_set,  T_MIN2,  T_MAX2,  12);
+    }
 
-    Send_Data.tx[2] = (pos_tmp >> 8);
-    Send_Data.tx[3] = pos_tmp;
-    Send_Data.tx[4] = (vel_tmp >> 4);
-    Send_Data.tx[5] = ((vel_tmp&0x0F)<<4)|(kp_tmp>>8);
-    Send_Data.tx[6] = kp_tmp;
-    Send_Data.tx[7] = (kd_tmp >> 4);
-    Send_Data.tx[8] = ((kd_tmp&0xF)<<4)|(tor_tmp>>8);
-    Send_Data.tx[9] = tor_tmp;
+    Send_Data.tx[0] = FRAME_HEADER;
+    Send_Data.tx[1] = static_cast<uint8_t>(motor.index);
 
-    Send_Data.tx[10]=Check_Sum(10,SEND_DATA_CHECK);   
-     
+    Send_Data.tx[2] = static_cast<uint8_t>(pos_tmp >> 8);
+    Send_Data.tx[3] = static_cast<uint8_t>(pos_tmp);
+    Send_Data.tx[4] = static_cast<uint8_t>(vel_tmp >> 4);
+    Send_Data.tx[5] = static_cast<uint8_t>(((vel_tmp & 0x0F) << 4) | (kp_tmp >> 8));
+    Send_Data.tx[6] = static_cast<uint8_t>(kp_tmp);
+    Send_Data.tx[7] = static_cast<uint8_t>(kd_tmp >> 4);
+    Send_Data.tx[8] = static_cast<uint8_t>(((kd_tmp & 0x0F) << 4) | (tor_tmp >> 8));
+    Send_Data.tx[9] = static_cast<uint8_t>(tor_tmp);
+
+    Send_Data.tx[10] = Check_Sum(10, SEND_DATA_CHECK);
+
     try
-    { //通过串口向下位机发送数据 
-      serial_motor.write(Send_Data.tx,sizeof(Send_Data.tx));
-    //ROS_INFO("Current time Motor: %f", interval.toSec());
-    }
-    catch (serial::IOException& e)   
     {
-      ROS_ERROR_STREAM("In send_motor_data,Unable to send data through motor serial port"); //If sending data fails, an error message is printed //如果发送数据失败，打印错误信息
+      serial_motor.write(Send_Data.tx.data(), Send_Data.tx.size());
     }
-
-  }  
-        
+    catch (serial::IOException& e)
+    {
+      ROS_ERROR_STREAM("In send_motor_data,Unable to send data through motor serial port: " << e.what());
+    }
+  }
 }
 
-
 void robot::fresh_cmd_motor_data(double pos, double vel,double torque, double kp,double kd,int motor_idx)
-{//更新发给电机的参数、力矩等
-  motors[motor_idx].pos_set = pos;
-  motors[motor_idx].vel_set = vel;
-  motors[motor_idx].tor_set = torque;
-  motors[motor_idx].kp = kp;
-  motors[motor_idx].kd = kd;                
+{
+  if (motor_idx < 0 || static_cast<std::size_t>(motor_idx) >= motors.size())
+  {
+    ROS_WARN_THROTTLE(1.0, "fresh_cmd_motor_data motor index %d out of range", motor_idx);
+    return;
+  }
+  auto& motor = motors[static_cast<std::size_t>(motor_idx)];
+  motor.pos_set = static_cast<float>(pos);
+  motor.vel_set = static_cast<float>(vel);
+  motor.tor_set = static_cast<float>(torque);
+  motor.kp = static_cast<float>(kp);
+  motor.kd = static_cast<float>(kd);
 }
 
 void robot::get_motor_data(double &pos,double &vel,double &torque, int motor_idx)
-{//获取电机反馈的参数、力矩等
-  pos = motors[motor_idx].pos;
-  vel = motors[motor_idx].vel;
-  torque =motors[motor_idx].tor;
+{
+  if (motor_idx < 0 || static_cast<std::size_t>(motor_idx) >= motors.size())
+  {
+    ROS_WARN_THROTTLE(1.0, "get_motor_data motor index %d out of range", motor_idx);
+    pos = 0.0;
+    vel = 0.0;
+    torque = 0.0;
+    return;
+  }
+  const auto& motor = motors[static_cast<std::size_t>(motor_idx)];
+  pos = motor.pos;
+  vel = motor.vel;
+  torque = motor.tor;
 }
 
-/**************************************
-功能: 串口通讯校验函数，数据包n有个字节，第n-1个字节为校验位，第n个字节位帧尾。第1个字节到第n-2个字节数据按位异或的结果与第n-1个字节对比，即为BCC校验
-输入参数： Count_Number：数据包前几个字节加入校验   mode：对发送数据还是接收数据进行校验
-***************************************/
 unsigned char robot::Check_Sum(unsigned char Count_Number,unsigned char mode)
 {
-    unsigned char check_sum=0,k;
+  const CheckMode check_mode = (mode == READ_DATA_CHECK) ? CheckMode::Receive : CheckMode::Send;
+  return computeChecksum(static_cast<std::size_t>(Count_Number), check_mode);
+}
 
-    if(mode==0) //Receive data mode //接收数据模式
+uint8_t robot::computeChecksum(std::size_t count_number, CheckMode mode) const
+{
+  uint8_t check_sum = 0;
+  if (mode == CheckMode::Receive)
+  {
+    const std::size_t max_count = std::min(count_number, receive_buffer_.size());
+    for (std::size_t k = 0; k < max_count; ++k)
     {
-        for(k=0;k<Count_Number;k++)
-        {
-            check_sum=check_sum^Receive_Data.rx[k]; //By bit or by bit //按位异或
-        }
+      check_sum = static_cast<uint8_t>(check_sum ^ receive_buffer_[k]);
     }
-
-    if(mode==1) //Send data mode //发送数据模式
+  }
+  else
+  {
+    const std::size_t max_count = std::min(count_number, Send_Data.tx.size());
+    for (std::size_t k = 0; k < max_count; ++k)
     {
-        for(k=0;k<Count_Number;k++)
-        {
-            check_sum=check_sum^Send_Data.tx[k]; //By bit or by bit //按位异或
-        }
+      check_sum = static_cast<uint8_t>(check_sum ^ Send_Data.tx[k]);
     }
-  return check_sum; //Returns the bitwise XOR result //返回按位异或结果
+  }
+  return check_sum;
 }
 
 void robot::dm4310_fbdata(motor_data_t& moto,uint8_t *data)
@@ -341,8 +530,8 @@ void robot::dm6006_fbdata(motor_data_t& moto,uint8_t *data)
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
   moto.pos = uint_to_float(moto.p_int, P_MIN3, P_MAX3, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN3, V_MAX3, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN3, T_MAX3, 12);  // (-10.0,10.0)
+  moto.vel = uint_to_float(moto.v_int, V_MIN3, V_MAX3, 12); // (-45.0,45.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN3, T_MAX3, 12);  // (-12.0,12.0)
 }
 
 void robot::dm8006_fbdata(motor_data_t& moto,uint8_t *data)
@@ -351,8 +540,8 @@ void robot::dm8006_fbdata(motor_data_t& moto,uint8_t *data)
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
   moto.pos = uint_to_float(moto.p_int, P_MIN4, P_MAX4, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN4, V_MAX4, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN4, T_MAX4, 12);  // (-10.0,10.0)
+  moto.vel = uint_to_float(moto.v_int, V_MIN4, V_MAX4, 12); // (-45.0,45.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN4, T_MAX4, 12);  // (-20.0,20.0)
 }
 
 void robot::dm6248p_fbdata(motor_data_t& moto,uint8_t *data)
@@ -360,9 +549,9 @@ void robot::dm6248p_fbdata(motor_data_t& moto,uint8_t *data)
   moto.p_int=(data[0]<<8)|data[1];
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
-  moto.pos = uint_to_float(moto.p_int, P_MIN5, P_MAX5, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN5, V_MAX5, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN5, T_MAX5, 12);  // (-10.0,10.0)
+  moto.pos = uint_to_float(moto.p_int, P_MIN5, P_MAX5, 16); // (-12.566,12.566)
+  moto.vel = uint_to_float(moto.v_int, V_MIN5, V_MAX5, 12); // (-20.0,20.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN5, T_MAX5, 12);  // (-120.0,120.0)
 }
 
 void robot::dm10010l_fbdata(motor_data_t& moto,uint8_t *data)
@@ -371,27 +560,21 @@ void robot::dm10010l_fbdata(motor_data_t& moto,uint8_t *data)
   moto.v_int=(data[2]<<4)|(data[3]>>4);
   moto.t_int=((data[3]&0x0F)<<8)|data[4];
   moto.pos = uint_to_float(moto.p_int, P_MIN6, P_MAX6, 16); // (-12.5,12.5)
-  moto.vel = uint_to_float(moto.v_int, V_MIN6, V_MAX6, 12); // (-30.0,30.0)
-  moto.tor = uint_to_float(moto.t_int, T_MIN6, T_MAX6, 12);  // (-10.0,10.0)
+  moto.vel = uint_to_float(moto.v_int, V_MIN6, V_MAX6, 12); // (-25.0,25.0)
+  moto.tor = uint_to_float(moto.t_int, T_MIN6, T_MAX6, 12);  // (-200.0,200.0)
 }
 
 int16_t robot::float_to_uint(float x_float, float x_min, float x_max, int bits)
 {
-  /* Converts a float to an unsigned int, given range and number of bits */
   float span = x_max - x_min;
   float offset = x_min;
-  return (int16_t)((x_float-offset)*((float)((1<<bits)-1))/span);
+  return static_cast<int16_t>((x_float - offset) * ((static_cast<float>((1 << bits) - 1)) / span));
 }
 
 float robot::uint_to_float(int x_int, float x_min, float x_max, int bits)
 {
-  /* converts unsigned int to float, given range and number of bits */
   float span = x_max - x_min;
-  float offset = x_min;
-  return ((float)x_int)*span/((float)((1<<bits)-1)) + offset;
+  return static_cast<float>(x_int) * span / static_cast<float>((1 << bits) - 1) + x_min;
 }
 
-
-}
-
-
+}  // namespace dmbot_serial

--- a/src/dmbot_serial_neck/src/stm32_motor_bridge.py
+++ b/src/dmbot_serial_neck/src/stm32_motor_bridge.py
@@ -11,9 +11,6 @@ from std_msgs.msg import Float64MultiArray, Float32
 FRAME_HEADER = 0x7B
 PACKET_LENGTH = 11  # 1B头 + 1B id + 8B payload + 1B XOR
 
-# ========= 新增：参数化 =========
-NUM_MOTORS = rospy.get_param("/stm32_motor_bridge/num_motors", 14)
-# ==============================
 
 def xor_checksum(data_bytes):
     c = 0
@@ -21,8 +18,9 @@ def xor_checksum(data_bytes):
         c ^= b
     return c & 0xFF
 
-def build_packet(motor_id, payload_8bytes):
-    assert 0 <= motor_id < NUM_MOTORS, "motor_id 越界"
+
+def build_packet(motor_id, payload_8bytes, num_motors):
+    assert 0 <= motor_id < num_motors, "motor_id 越界"
     if len(payload_8bytes) != 8:
         raise ValueError("payload 必须 8 字节")
     buf = bytearray(10)
@@ -32,51 +30,57 @@ def build_packet(motor_id, payload_8bytes):
     chksum = xor_checksum(buf)
     return bytes(buf) + bytes([chksum])
 
-def clamp_int16(v): return max(-32768, min(32767, int(round(v))))
+
+def clamp_int16(v):
+    return max(-32768, min(32767, int(round(v))))
+
 
 def encode_pd_q15(pos, vel, kp, kd, scale=1000, big_endian=True):
     # 注意：如果下位机忽略 vel，你也可以置 0
     p = clamp_int16(pos * scale)
     v = clamp_int16(vel * scale)
-    kpp = clamp_int16(kp  * scale)
-    kdd = clamp_int16(kd  * scale)
+    kpp = clamp_int16(kp * scale)
+    kdd = clamp_int16(kd * scale)
     vals = [p, v, kpp, kdd]
     b = bytearray(8)
     for i, val in enumerate(vals):
         if big_endian:
-            b[2*i]   = (val >> 8) & 0xFF
-            b[2*i+1] =  val       & 0xFF
+            b[2 * i] = (val >> 8) & 0xFF
+            b[2 * i + 1] = val & 0xFF
         else:
-            b[2*i]   =  val       & 0xFF
-            b[2*i+1] = (val >> 8) & 0xFF
+            b[2 * i] = val & 0xFF
+            b[2 * i + 1] = (val >> 8) & 0xFF
     return b
+
 
 class Stm32Bridge(object):
     def __init__(self):
-        self.port   = rospy.get_param("~port", "/dev/ttyACM1")
-        self.baud   = int(rospy.get_param("~baud", 921600))       # 改成 921600
-        self.rate_hz= float(rospy.get_param("~rate", 100.0))
-        self.mode   = rospy.get_param("~mode", "pd_q15")
-        self.scale  = float(rospy.get_param("~scale", 1000.0))
+        self.robot_name = rospy.get_param("~robot_name", rospy.get_param("robot_name", "ludan"))
+        self.num_motors = self._resolve_motor_count()
+        rospy.loginfo("stm32_motor_bridge: %s using %d motors", self.robot_name, self.num_motors)
+
+        self.port = rospy.get_param("~port", "/dev/ttyACM1")
+        self.baud = int(rospy.get_param("~baud", 921600))
+        self.rate_hz = float(rospy.get_param("~rate", 100.0))
+        self.mode = rospy.get_param("~mode", "pd_q15")
+        self.scale = float(rospy.get_param("~scale", 1000.0))
         self.big_endian = bool(rospy.get_param("~big_endian", True))
 
-        # /hybrid_cmd 长度 = 5*NUM_MOTORS
-        self.cmd = [0.0] * (5 * NUM_MOTORS)
+        self.cmd = [0.0] * (5 * self.num_motors)
         self.cmd_lock = threading.Lock()
         self.last_cmd_time = 0.0
         self.timeout = float(rospy.get_param("~timeout", 0.2))
 
         self.emergency_stop = False
 
-        # 方向映射长度改成 NUM_MOTORS（按你实际填充）
-        default_dir = [1]*NUM_MOTORS
-        # 例：原来 10 路是 [ 1,1,-1,1,1, -1,1,-1,-1,-1 ]
-        # 你可以在参数服务器覆盖，也可以这里直接写 14 路的表
-        self.direction = rospy.get_param("~direction", default_dir)
+        default_dir = [1] * self.num_motors
+        direction_param = rospy.get_param("~direction", default_dir)
+        if len(direction_param) < self.num_motors:
+            direction_param = list(direction_param) + [1] * (self.num_motors - len(direction_param))
+        self.direction = list(direction_param[:self.num_motors])
 
-        # raw8 的默认 payload
         self.raw_payload_default = [0x7F, 0xFF, 0x84, 0x30, 0x00, 0x33, 0x37, 0xFF]
-        self.raw_payloads = [bytearray(self.raw_payload_default) for _ in range(NUM_MOTORS)]
+        self.raw_payloads = [bytearray(self.raw_payload_default) for _ in range(self.num_motors)]
 
         self.ser = serial.Serial(self.port, self.baud, timeout=0.05)
         rospy.loginfo("stm32_motor_bridge 串口已打开 %s @ %d", self.port, self.baud)
@@ -84,8 +88,7 @@ class Stm32Bridge(object):
         rospy.Subscriber("/hybrid_cmd", Float64MultiArray, self.hybrid_cb, queue_size=1)
         rospy.Subscriber("/emergency_stop", Float32, self.emg_cb, queue_size=1)
 
-        # raw8 订阅也扩到 NUM_MOTORS
-        for mid in range(NUM_MOTORS):
+        for mid in range(self.num_motors):
             rospy.Subscriber(f"/stm32/raw8/motor{mid}", Float64MultiArray,
                              lambda msg, i=mid: self.raw8_cb(i, msg), queue_size=1)
 
@@ -93,9 +96,34 @@ class Stm32Bridge(object):
         self.th = threading.Thread(target=self.loop, daemon=True)
         self.th.start()
 
+    @staticmethod
+    def _count_from_layout(layout):
+        return len(layout) if isinstance(layout, list) and len(layout) > 0 else 0
+
+    def _resolve_motor_count(self):
+        layout = rospy.get_param("~motor_layout", None)
+        count = self._count_from_layout(layout)
+        if count:
+            return count
+
+        if self.robot_name:
+            global_layout = rospy.get_param(f"/{self.robot_name}/motor_layout", None)
+            count = self._count_from_layout(global_layout)
+            if count:
+                rospy.set_param("~motor_layout", global_layout)
+                return count
+
+        fallback_layout = rospy.get_param("/motor_layout", None)
+        count = self._count_from_layout(fallback_layout)
+        if count:
+            rospy.set_param("~motor_layout", fallback_layout)
+            return count
+
+        return int(rospy.get_param("~num_motors", rospy.get_param("/stm32_motor_bridge/num_motors", 14)))
+
     def hybrid_cb(self, msg: Float64MultiArray):
         data = list(msg.data)
-        need = 5 * NUM_MOTORS
+        need = 5 * self.num_motors
         if len(data) != need:
             rospy.logwarn_throttle(1.0, "/hybrid_cmd 长度=%d（需 %d），忽略", len(data), need)
             return
@@ -108,6 +136,9 @@ class Stm32Bridge(object):
         rospy.logwarn("收到急停: %s", self.emergency_stop)
 
     def raw8_cb(self, motor_id, msg: Float64MultiArray):
+        if not (0 <= motor_id < self.num_motors):
+            rospy.logwarn_throttle(1.0, "raw8 motor id %d 越界", motor_id)
+            return
         arr = msg.data
         if len(arr) != 8:
             rospy.logwarn("raw8 电机 %d 长度=%d(需8)，忽略", motor_id, len(arr))
@@ -128,14 +159,12 @@ class Stm32Bridge(object):
             with self.cmd_lock:
                 d = self.cmd[:]
 
-            # 切片都按 NUM_MOTORS
-            pos = d[0:NUM_MOTORS]
-            vel = d[NUM_MOTORS:2*NUM_MOTORS]
-            kp  = d[2*NUM_MOTORS:3*NUM_MOTORS]
-            kd  = d[3*NUM_MOTORS:4*NUM_MOTORS]
-            # tau = d[4*NUM_MOTORS:5*NUM_MOTORS]  # 如固件不用可忽略
+            pos = d[0:self.num_motors]
+            vel = d[self.num_motors:2 * self.num_motors]
+            kp = d[2 * self.num_motors:3 * self.num_motors]
+            kd = d[3 * self.num_motors:4 * self.num_motors]
 
-            for mid in range(NUM_MOTORS):
+            for mid in range(self.num_motors):
                 if self.mode == "raw8":
                     payload = self.raw_payloads[mid]
                 else:
@@ -145,7 +174,7 @@ class Stm32Bridge(object):
                     kdd = kd[mid]
                     payload = encode_pd_q15(p, v, kpp, kdd, scale=self.scale, big_endian=self.big_endian)
 
-                pkt = build_packet(mid, payload)
+                pkt = build_packet(mid, payload, self.num_motors)
                 try:
                     self.ser.write(pkt)
                 except Exception as e:
@@ -158,11 +187,12 @@ class Stm32Bridge(object):
         self.run = False
         try:
             self.th.join(timeout=1.0)
-        except:
+        except Exception:
             pass
         if self.ser and self.ser.is_open:
             self.ser.close()
         rospy.loginfo("stm32_motor_bridge 已关闭")
+
 
 if __name__ == "__main__":
     rospy.init_node("stm32_motor_bridge")

--- a/src/dmbot_serial_neck/src/test_motor.cpp
+++ b/src/dmbot_serial_neck/src/test_motor.cpp
@@ -4,8 +4,6 @@
 #include <vector>
 #include <iostream>
 
-static constexpr int N = NUM_MOTORS;  // 14
-
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "test_motor");
@@ -25,27 +23,33 @@ int main(int argc, char **argv)
 
   // 创建上位机串口接口
   dmbot_serial::robot rb;
+  const std::size_t motor_count = rb.motorCount();
+  if (motor_count == 0)
+  {
+    ROS_ERROR("未配置任何电机，退出 test_motor");
+    return 1;
+  }
 
-  std::vector<double> pos_cmd(N, 0.0), vel_cmd(N, 0.0), tor_cmd(N, 0.0);
+  std::vector<double> pos_cmd(motor_count, 0.0), vel_cmd(motor_count, 0.0), tor_cmd(motor_count, 0.0);
 
   const double two_pi = 2.0 * M_PI;
   const double dt = 1.0 / 200.0;
   double t = 0.0;
 
-  ROS_INFO("test_motor running with N=%d, pos_amp=%.3f rad, freq=%.3f Hz, kp=%.3f, kd=%.3f",
-           N, pos_amp, freq, kp, kd);
+  ROS_INFO("test_motor running with N=%zu, pos_amp=%.3f rad, freq=%.3f Hz, kp=%.3f, kd=%.3f",
+           motor_count, pos_amp, freq, kp, kd);
   ROS_INFO("默认不动，若要小幅测试请传参：_pos_amp:=0.05 _kp:=2.0 _kd:=0.1");
 
   while (ros::ok())
   {
-    // 生成 14 路命令（简单正弦，带相位错开，便于识别）
-    for (int i = 0; i < N; ++i)
+    // 生成多路命令（简单正弦，带相位错开，便于识别）
+    for (std::size_t i = 0; i < motor_count; ++i)
     {
-      double phase = (two_pi * i) / N;
+      double phase = (two_pi * static_cast<double>(i)) / static_cast<double>(motor_count);
       pos_cmd[i] = pos_amp * std::sin(two_pi * freq * t + phase);
       vel_cmd[i] = 0.0;   // 如固件需要也可给导数
       tor_cmd[i] = 0.0;
-      rb.fresh_cmd_motor_data(pos_cmd[i], vel_cmd[i], tor_cmd[i], kp, kd, i);
+      rb.fresh_cmd_motor_data(pos_cmd[i], vel_cmd[i], tor_cmd[i], kp, kd, static_cast<int>(i));
     }
 
     // 下发给 STM32
@@ -53,10 +57,18 @@ int main(int argc, char **argv)
 
     // 可选：打印少量反馈
     if (static_cast<int>(t*10) % 10 == 0) { // 约每 0.1s 打印一次
-      double p0,v0,t0, p7,v7,t7, p13,v13,t13;
+      double p0 = 0.0, v0 = 0.0, t0 = 0.0;
+      double p7 = 0.0, v7 = 0.0, t7 = 0.0;
+      double p13 = 0.0, v13 = 0.0, t13 = 0.0;
       rb.get_motor_data(p0,v0,t0,0);
-      rb.get_motor_data(p7,v7,t7,7);
-      rb.get_motor_data(p13,v13,t13,13);
+      if (motor_count > 7)
+      {
+        rb.get_motor_data(p7,v7,t7,7);
+      }
+      if (motor_count > 13)
+      {
+        rb.get_motor_data(p13,v13,t13,13);
+      }
       ROS_INFO_THROTTLE(0.5, "m0 pos=%.3f, m7 pos=%.3f, m13 pos=%.3f", p0, p7, p13);
     }
 


### PR DESCRIPTION
## Summary
- replace hard-coded motor arrays with a motor_layout configuration that generates structured names for Ludan limbs and joints
- synchronize the left-arm and neck variants plus STM32 bridge scripts to use the same dynamic motor count handling
- document the new parameters and configuration workflow for Ludan in the README

## Testing
- python3 -m py_compile src/dmbot_serial/src/stm32_motor_bridge.py src/dmbot_serial_leftarm/src/stm32_motor_bridge.py src/dmbot_serial_neck/src/stm32_motor_bridge.py

------
https://chatgpt.com/codex/tasks/task_b_68d6a46f26348323924257156880c431